### PR TITLE
feat(quests): show what to beat, and let a movement be swapped out

### DIFF
--- a/__tests__/content-invariants.test.ts
+++ b/__tests__/content-invariants.test.ts
@@ -228,6 +228,36 @@ describe("content invariants", () => {
     expect(offenders).toEqual([]);
   });
 
+  /**
+   * Substitution can only ever offer what the catalogue holds, so "can this hero swap out of a
+   * movement they cannot do?" is a property of the *content*, not of the picker.
+   *
+   * It is not hypothetical: every seeded `pull_vertical` movement requires a bar, so a hero
+   * without one has no same-pattern option at all on a Pull-ups slot — the ladder is the only
+   * route out, and only walked to its end. This fails the moment someone seeds a pattern with no
+   * equipment-free way down.
+   */
+  test("every movement has an equipment-free substitute that is worth explaining", async () => {
+    const { listExercises } = require("../db/exercises") as typeof import("../db/exercises");
+    const { rankSwapCandidates } =
+      require("../constants/exerciseFilters") as typeof import("../constants/exerciseFilters");
+
+    const all = await listExercises();
+    expect(all.length).toBeGreaterThan(0);
+
+    // An empty set, not null: the hero who answered "I own nothing" is the hard case.
+    const stranded = all
+      .filter(
+        (ex) =>
+          !rankSwapCandidates(all, ex, new Set()).some(
+            (c) => c.reason !== null && c.exercise.equipment === "none",
+          ),
+      )
+      .map((ex) => `${ex.enName} (${ex.pattern ?? "no pattern"})`);
+
+    expect(stranded).toEqual([]);
+  });
+
   test("a quest is either equipment-free or a declared equipment quest", async () => {
     const all = await loadQuests();
 

--- a/__tests__/db-personalRecords.test.ts
+++ b/__tests__/db-personalRecords.test.ts
@@ -1,4 +1,19 @@
+import assert from "node:assert/strict";
+
 import { clientMock, createTestDb } from "./helpers/testDb";
+
+/**
+ * Any seeded movement will do — these tests are about the fold over `completed_exercises`, not
+ * about which exercise it is. `assert` rather than `?? 1`: a fallback id would silently test
+ * nothing if the migrations ever stopped seeding a catalogue.
+ */
+function firstExerciseId(t: ReturnType<typeof createTestDb>): number {
+  const row = t.sqlite.prepare("SELECT id FROM exercises LIMIT 1").get() as
+    | { id: number }
+    | undefined;
+  assert(row);
+  return row.id;
+}
 
 describe("db/personalRecords", () => {
   const t = createTestDb();
@@ -63,63 +78,104 @@ describe("db/personalRecords", () => {
     expect(result?.sessionId).toBe(2);
   });
 
-  test("getExerciseMax returns null for unseen exercise", async () => {
-    const { getExerciseMax } =
+  test("getExerciseHistory returns an empty map for no ids", async () => {
+    const { getExerciseHistory } =
       require("../db/personalRecords") as typeof import("../db/personalRecords");
-    const result = await getExerciseMax(999);
-    expect(result).toBeNull();
+    expect(await getExerciseHistory([])).toEqual(new Map());
   });
 
-  test("getExerciseMax returns the max reps for an exercise", async () => {
-    const { getExerciseMax } =
+  test("getExerciseHistory skips a movement with nothing logged", async () => {
+    const { getExerciseHistory } =
       require("../db/personalRecords") as typeof import("../db/personalRecords");
-    const now = Math.floor(Date.now() / 1000);
+    const history = await getExerciseHistory([999]);
 
-    // Get a real exercise ID
-    const exerciseRow = t.sqlite.prepare(`SELECT id FROM exercises LIMIT 1`).get() as
-      | { id: number }
-      | undefined;
-    const exerciseId = exerciseRow?.id ?? 1;
-
-    t.sqlite.exec(`
-      INSERT INTO completed_sessions (id, performedAt) VALUES (1, ${now}), (2, ${now});
-      INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
-        (1, ${exerciseId}, 'reps', 15, ${now}, 0),
-        (2, ${exerciseId}, 'reps', 20, ${now}, 0);
-    `);
-
-    const result = await getExerciseMax(exerciseId);
-    expect(result).not.toBeNull();
-    expect(result?.type).toBe("exercise_max_reps");
-    expect(result?.value).toBe(20);
+    // Absent, not zero: the screen shows no ghost line at all rather than "last time: 0".
+    expect(history.has("999:reps")).toBe(false);
   });
 
   /**
-   * Regression: reps and seconds share the resultValue column, and the max was taken across
-   * both. A 60 s hold therefore outranked every rep set on the same movement and reported
-   * itself as a rep record.
+   * Regression: reps and seconds share the resultValue column, and a pooled max let a 60 s hold
+   * outrank every rep set on the same movement and report itself as a rep record.
    */
-  test("getExerciseMax keeps reps and seconds apart", async () => {
-    const { getExerciseMax } =
+  test("getExerciseHistory keeps reps and seconds apart", async () => {
+    const { getExerciseHistory, ghostKey } =
       require("../db/personalRecords") as typeof import("../db/personalRecords");
     const now = Math.floor(Date.now() / 1000);
-    const exerciseRow = t.sqlite.prepare(`SELECT id FROM exercises LIMIT 1`).get() as
-      | { id: number }
-      | undefined;
-    const exerciseId = exerciseRow?.id ?? 1;
+    const exerciseId = firstExerciseId(t);
 
+    t.sqlite.exec(`
+      INSERT INTO completed_sessions (id, performedAt) VALUES (1, ${now}), (2, ${now + 60});
+      INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
+        (1, ${exerciseId}, 'reps', 12, ${now}, 0),
+        (2, ${exerciseId}, 'time', 90, ${now + 60}, 0);
+    `);
+
+    const history = await getExerciseHistory([exerciseId]);
+    expect(history.get(ghostKey(exerciseId, "reps"))).toEqual({ last: 12, best: 12 });
+    expect(history.get(ghostKey(exerciseId, "time"))).toEqual({ last: 90, best: 90 });
+  });
+
+  /**
+   * The whole point of the function, and the one thing a naive MAX gets wrong: "what to beat" is
+   * the last session, "your record" is all time, and the two are different numbers whenever the
+   * hero has had a better day earlier.
+   */
+  test("getExerciseHistory separates the last session from the all-time best", async () => {
+    const { getExerciseHistory, ghostKey } =
+      require("../db/personalRecords") as typeof import("../db/personalRecords");
+    const now = Math.floor(Date.now() / 1000);
+    const exerciseId = firstExerciseId(t);
+
+    t.sqlite.exec(`
+      INSERT INTO completed_sessions (id, performedAt) VALUES
+        (1, ${now - 7200}), (2, ${now - 3600}), (3, ${now});
+      INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
+        (1, ${exerciseId}, 'reps', 10, ${now - 7200}, 0),
+        (2, ${exerciseId}, 'reps', 25, ${now - 3600}, 0),
+        (3, ${exerciseId}, 'reps', 18, ${now}, 0);
+    `);
+
+    const history = await getExerciseHistory([exerciseId]);
+    expect(history.get(ghostKey(exerciseId, "reps"))).toEqual({ last: 18, best: 25 });
+  });
+
+  test("getExerciseHistory reports the best round of the last session, not its last row", async () => {
+    const { getExerciseHistory, ghostKey } =
+      require("../db/personalRecords") as typeof import("../db/personalRecords");
+    const now = Math.floor(Date.now() / 1000);
+    const exerciseId = firstExerciseId(t);
+
+    // A 12/10/8 quest: the hero cleared 12 and faded. Reporting 8 would name a floor they beat
+    // twice on the way down.
+    t.sqlite.exec(`
+      INSERT INTO completed_sessions (id, performedAt) VALUES (1, ${now});
+      INSERT INTO completed_exercises (sessionId, exerciseId, roundIndex, resultType, resultValue, performedAt, sortOrder) VALUES
+        (1, ${exerciseId}, 0, 'reps', 12, ${now}, 0),
+        (1, ${exerciseId}, 1, 'reps', 10, ${now + 1}, 0),
+        (1, ${exerciseId}, 2, 'reps', 8, ${now + 2}, 0);
+    `);
+
+    const history = await getExerciseHistory([exerciseId]);
+    expect(history.get(ghostKey(exerciseId, "reps"))).toEqual({ last: 12, best: 12 });
+  });
+
+  test("getExerciseHistory breaks a same-second tie on the session id", async () => {
+    const { getExerciseHistory, ghostKey } =
+      require("../db/personalRecords") as typeof import("../db/personalRecords");
+    const now = Math.floor(Date.now() / 1000);
+    const exerciseId = firstExerciseId(t);
+
+    // Two sessions written in the same second share a timestamp, so the timestamp alone leaves
+    // the answer up to row order.
     t.sqlite.exec(`
       INSERT INTO completed_sessions (id, performedAt) VALUES (1, ${now}), (2, ${now});
       INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
-        (1, ${exerciseId}, 'reps', 12, ${now}, 0),
-        (2, ${exerciseId}, 'time', 90, ${now}, 0);
+        (1, ${exerciseId}, 'reps', 20, ${now}, 0),
+        (2, ${exerciseId}, 'reps', 14, ${now}, 0);
     `);
 
-    const reps = await getExerciseMax(exerciseId, "reps");
-    expect(reps).toMatchObject({ type: "exercise_max_reps", value: 12 });
-
-    const hold = await getExerciseMax(exerciseId, "time");
-    expect(hold).toMatchObject({ type: "exercise_max_time", value: 90 });
+    const history = await getExerciseHistory([exerciseId]);
+    expect(history.get(ghostKey(exerciseId, "reps"))).toEqual({ last: 14, best: 20 });
   });
 
   test("getPersonalRecordsSummary returns all records and session count", async () => {

--- a/__tests__/db-quest-config.test.ts
+++ b/__tests__/db-quest-config.test.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert/strict";
+
 import type { Quest } from "@/db/quests";
 import { Difficulty } from "@/db/targets";
 import { clientMock, createTestDb } from "./helpers/testDb";
@@ -9,8 +11,15 @@ const t = createTestDb();
 jest.resetModules();
 jest.doMock("../db/client", () => clientMock(t));
 
-const { applyQuestConfig, hasQuestOverrides, parseQuestConfig } =
-  require("../db/questConfig") as typeof import("../db/questConfig");
+const {
+  applyQuestConfig,
+  hasQuestOverrides,
+  indexExercises,
+  loadConfiguredQuest,
+  parseQuestConfig,
+  saveQuestConfig,
+  clearQuestConfig,
+} = require("../db/questConfig") as typeof import("../db/questConfig");
 
 function makeQuest(): Quest {
   const exercise = {
@@ -43,11 +52,38 @@ function makeQuest(): Quest {
     archetype: null,
     imagePath: "assets/placeholder.jpg",
     exercises: [
-      { id: 11, exercise, images: [], target: { type: "reps", value: 10 } },
+      {
+        id: 11,
+        exercise,
+        // Quest-specific art *of this movement* — the thing a substitution has to drop.
+        images: ["assets/squat_a.webp"],
+        target: { type: "reps", value: 10 },
+        ghost: { last: 18, best: 25 },
+      },
       { id: 12, exercise, images: [], target: { type: "time", value: 30 } },
     ],
   };
 }
+
+/** A different movement, to put in a slot. */
+const dip: Quest["exercises"][number]["exercise"] = {
+  id: 2,
+  enName: "Dip",
+  frName: "Dip",
+  enDescription: "",
+  frDescription: "",
+  imagePath: "assets/dip.jpg",
+  creator: "Admin",
+  difficulty: "hard",
+  equipment: "none",
+  style: "calisthenics",
+  secondsPerRep: 3,
+  pattern: "push_vertical",
+  prerequisiteExerciseId: null,
+  muscles: ["arms"],
+};
+
+const CATALOGUE = indexExercises([dip]);
 
 describe("db/questConfig", () => {
   afterAll(() => {
@@ -82,25 +118,29 @@ describe("db/questConfig", () => {
     const config = { level: Difficulty.Medium, roundRestSeconds: 120 };
 
     expect(hasQuestOverrides(config)).toBe(true);
-    expect(applyQuestConfig(quest, config).roundRestSeconds).toBe(120);
+    expect(applyQuestConfig(quest, config, CATALOGUE).roundRestSeconds).toBe(120);
   });
 
   test("a level-only config changes nothing about the quest", () => {
     const quest = makeQuest();
     expect(hasQuestOverrides({ level: Difficulty.Hard })).toBe(false);
-    expect(applyQuestConfig(quest, { level: Difficulty.Hard })).toBe(quest);
-    expect(applyQuestConfig(quest, null)).toBe(quest);
+    expect(applyQuestConfig(quest, { level: Difficulty.Hard }, CATALOGUE)).toBe(quest);
+    expect(applyQuestConfig(quest, null, CATALOGUE)).toBe(quest);
   });
 
   test("overrides replace rounds, both rests and the targets they name", () => {
     const quest = makeQuest();
-    const configured = applyQuestConfig(quest, {
-      level: Difficulty.Medium,
-      rounds: 5,
-      restSeconds: 45,
-      roundRestSeconds: 120,
-      targets: { 12: 60, 999: 5 },
-    });
+    const configured = applyQuestConfig(
+      quest,
+      {
+        level: Difficulty.Medium,
+        rounds: 5,
+        restSeconds: 45,
+        roundRestSeconds: 120,
+        targets: { 12: 60, 999: 5 },
+      },
+      CATALOGUE,
+    );
 
     expect(configured.rounds).toBe(5);
     expect(configured.restSeconds).toBe(45);
@@ -112,5 +152,112 @@ describe("db/questConfig", () => {
     // The template the rest of the app shares must not be mutated.
     expect(quest.rounds).toBe(3);
     expect(quest.exercises[1]?.target.value).toBe(30);
+  });
+  test("parse repairs a swaps map the same way it repairs targets", () => {
+    // An exercise id is either an id or nothing. Clamping a corrupt 3.7 would round it into
+    // exercise 4, which exists — a silently wrong movement is worse than no override.
+    expect(
+      parseQuestConfig(
+        JSON.stringify({ level: "medium", swaps: { 11: 3.7, 12: 0, 13: "x", 14: -2 } }),
+      ),
+    ).toEqual({ level: Difficulty.Medium });
+
+    expect(parseQuestConfig(JSON.stringify({ level: "medium", swaps: { 11: 2 } }))).toEqual({
+      level: Difficulty.Medium,
+      swaps: { 11: 2 },
+    });
+  });
+
+  test("a swap on its own counts as an override", () => {
+    // Otherwise the "Custom" tag and "Back to defaults" would both lie about a changed quest.
+    expect(hasQuestOverrides({ level: Difficulty.Medium, swaps: { 11: 2 } })).toBe(true);
+  });
+
+  test("a swap replaces the movement and drops the art of the one it replaced", () => {
+    const quest = makeQuest();
+    const configured = applyQuestConfig(
+      quest,
+      { level: Difficulty.Medium, swaps: { 11: dip.id } },
+      CATALOGUE,
+    );
+
+    const slot = configured.exercises[0];
+    expect(slot?.exercise.enName).toBe("Dip");
+    // `images` is the quest's art of the *old* movement, off `quest_exercises.imagesJson`. Kept,
+    // the card would illustrate a squat above the word "Dip".
+    expect(slot?.images).toEqual([]);
+    // Same for the ghost: it is the old movement's history, and the substitute's is not here.
+    expect(slot?.ghost).toBeUndefined();
+
+    // The slot that was not swapped is untouched, art and ghost included.
+    expect(configured.exercises[1]?.exercise.enName).toBe("Squat");
+
+    // And the shared template is not mutated.
+    expect(quest.exercises[0]?.exercise.enName).toBe("Squat");
+    expect(quest.exercises[0]?.images).toEqual(["assets/squat_a.webp"]);
+  });
+
+  test("a swap naming an exercise the catalogue does not have is ignored", () => {
+    const quest = makeQuest();
+    const configured = applyQuestConfig(
+      quest,
+      // 4242 is not in CATALOGUE; 999 is not a slot in this quest. Both are reachable states —
+      // content updates rewrite `quest_exercises` rows and retire exercises.
+      { level: Difficulty.Medium, swaps: { 11: 4242, 999: 2 } },
+      CATALOGUE,
+    );
+
+    expect(configured.exercises[0]?.exercise.enName).toBe("Squat");
+    expect(configured.exercises[0]?.images).toEqual(["assets/squat_a.webp"]);
+  });
+
+  test("a target and a swap on different slots both apply", () => {
+    const quest = makeQuest();
+    const configured = applyQuestConfig(
+      quest,
+      { level: Difficulty.Medium, swaps: { 11: dip.id }, targets: { 12: 45 } },
+      CATALOGUE,
+    );
+
+    expect(configured.exercises[0]?.exercise.enName).toBe("Dip");
+    expect(configured.exercises[1]?.target.value).toBe(45);
+  });
+  /**
+   * The one that matters most. AGENTS.md's known-debt entry says Home and the quest screen must
+   * keep reading the same saved config "or they will start different sessions for the same
+   * quest" — and a substitution is exactly what would make them diverge: Home starts the movement
+   * the template names, the quest screen starts the one the hero chose.
+   *
+   * This exercises Home's path (`loadConfiguredQuest`) against the real seeded database, which is
+   * the only way to catch the catalogue never being threaded in.
+   */
+  test("Home's path starts the movement the hero swapped in", async () => {
+    const quests = require("../db/quests") as typeof import("../db/quests");
+    const exercisesDb = require("../db/exercises") as typeof import("../db/exercises");
+
+    const templates = await quests.listQuestTemplates();
+    const seeded = templates.find((q) => q.frTitle === "Couper du bois");
+    assert(seeded);
+
+    const before = await loadConfiguredQuest(seeded.id);
+    assert(before);
+    const slot = before.quest.exercises[0];
+    assert(slot);
+    expect(slot.exercise.enName).toBe("Squat");
+
+    const all = await exercisesDb.listExercises();
+    const substitute = all.find((e) => e.enName === "Wall Sit");
+    assert(substitute);
+
+    await saveQuestConfig(seeded.id, {
+      level: Difficulty.Medium,
+      swaps: { [String(slot.id)]: substitute.id },
+    });
+
+    const after = await loadConfiguredQuest(seeded.id);
+    assert(after);
+    expect(after.quest.exercises[0]?.exercise.enName).toBe("Wall Sit");
+
+    await clearQuestConfig(seeded.id);
   });
 });

--- a/__tests__/db-quests.test.ts
+++ b/__tests__/db-quests.test.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert/strict";
+
 import { clientMock, createTestDb } from "./helpers/testDb";
 
 describe("db/quests", () => {
@@ -86,6 +88,57 @@ describe("db/quests", () => {
     expect(third.exercise.enName).toBe("Plank");
     expect(third.target.type).toBe("time");
     expect(third.target.value).toBe(29);
+  });
+
+  /**
+   * The ghost only matters if it reaches the object the session screen and the quest screen both
+   * read — `getQuestById`'s output. Testing the query alone would not have caught a slot picking
+   * up the wrong unit, which is the one way this can be wrong and still look right.
+   */
+  test("getQuestById carries the journal onto each slot, in that slot's unit", async () => {
+    const quests = require("../db/quests") as typeof import("../db/quests");
+
+    const templates = await quests.listQuestTemplates();
+    const seeded = templates.find((q) => q.frTitle === "Couper du bois");
+    assert(seeded);
+
+    const before = await quests.getQuestById(seeded.id, quests.Difficulty.Easy);
+    assert(before);
+    const squatId = before.exercises[0]?.exercise.id;
+    const plankId = before.exercises[2]?.exercise.id;
+    assert(squatId);
+    assert(plankId);
+
+    // No history yet: no ghost at all, rather than a zero.
+    expect(before.exercises[0]?.ghost).toBeUndefined();
+
+    const now = Math.floor(Date.now() / 1000);
+    t.sqlite.exec(`
+      INSERT INTO completed_sessions (id, performedAt) VALUES (9001, ${now});
+      INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
+        (9001, ${squatId}, 'reps', 22, ${now}, 0),
+        (9001, ${squatId}, 'time', 600, ${now}, 1),
+        (9001, ${plankId}, 'time', 600, ${now}, 2);
+    `);
+
+    const after = await quests.getQuestById(seeded.id, quests.Difficulty.Easy);
+    assert(after);
+
+    // The squat slot asks for reps, so it must show the 22 — never the 600 s hold logged against
+    // the same movement, which is what a pooled max would have handed it.
+    const squat = after.exercises[0];
+    expect(squat?.target.type).toBe("reps");
+    expect(squat?.ghost).toEqual({ last: 22, best: 22 });
+
+    // The plank slot asks for a hold, so its ghost is in seconds — and the same record still
+    // drives the prescription, which is the behaviour this read replaced `getMaxHoldSeconds` for.
+    const plank = after.exercises[2];
+    expect(plank?.target.type).toBe("time");
+    expect(plank?.ghost).toEqual({ last: 600, best: 600 });
+    expect(plank?.target.value ?? 0).toBeGreaterThan(29);
+
+    t.sqlite.exec(`DELETE FROM completed_exercises WHERE sessionId = 9001`);
+    t.sqlite.exec(`DELETE FROM completed_sessions WHERE id = 9001`);
   });
 
   test("create/update/set/delete quest template", async () => {

--- a/__tests__/exercise-filters.test.ts
+++ b/__tests__/exercise-filters.test.ts
@@ -3,6 +3,8 @@ import {
   type ExerciseFilters,
   filterExercises,
   NO_EXERCISE_FILTERS,
+  rankSwapCandidates,
+  type SwapCandidate,
 } from "@/constants/exerciseFilters";
 import type { Exercise } from "@/db/exercises";
 
@@ -159,5 +161,89 @@ describe("filterExercises", () => {
       LEADS_TO,
     );
     expect(ids(out)).toEqual([2]);
+  });
+});
+
+describe("rankSwapCandidates", () => {
+  const reasonOf = (out: SwapCandidate[], id: number) =>
+    out.find((c) => c.exercise.id === id)?.reason;
+
+  it("never offers the movement it is replacing", () => {
+    const out = rankSwapCandidates(ALL, pullUp, null);
+    expect(out.some((c) => c.exercise.id === pullUp.id)).toBe(false);
+    expect(out).toHaveLength(ALL.length - 1);
+  });
+
+  /**
+   * The regression this whole feature exists for. Every seeded `pull_vertical` movement needs a
+   * bar, so "same pattern" alone hands a bar-less hero an empty sheet on a Pull-ups slot — and so
+   * does a one-rung ladder step, because the rung below a pull-up is another pull-up. Only the
+   * full walk reaches a movement they can actually do tonight.
+   */
+  it("reaches an equipment-free movement for a bar-less hero, through the ladder", () => {
+    const out = rankSwapCandidates(ALL, pullUp, new Set());
+
+    const firstFree = out.find((c) => c.exercise.equipment === "none");
+    expect(firstFree).toBeDefined();
+    expect(firstFree?.reason).not.toBeNull();
+
+    // And it leads the list: nothing the hero cannot lift outranks something they can.
+    expect(out[0]?.exercise.equipment).toBe("none");
+  });
+
+  it("sinks unowned equipment inside its tier instead of hiding it", () => {
+    const barRow = makeExercise({
+      id: 6,
+      enName: "Bar Row",
+      equipment: "pullup_bar",
+      pattern: "pull_horizontal",
+    });
+    const out = rankSwapCandidates([...ALL, barRow], tableRow, new Set());
+
+    // Still offered — the hero decides what is in the room — but behind the free ones.
+    const positions = out.map((c) => c.exercise.id);
+    expect(positions).toContain(barRow.id);
+    expect(positions.indexOf(invertedRow.id)).toBeLessThan(positions.indexOf(barRow.id));
+  });
+
+  it("names why each movement is offered", () => {
+    const out = rankSwapCandidates(ALL, invertedRow, null);
+
+    expect(reasonOf(out, tableRow.id)).toBe("easier");
+    expect(reasonOf(out, pullUp.id)).toBe("harder");
+    // Off the ladder and a different family entirely.
+    expect(reasonOf(out, pushUp.id)).toBeNull();
+  });
+
+  it("reports a same-pattern movement that is not on the ladder", () => {
+    const dip = makeExercise({ id: 7, enName: "Dip", pattern: "push_horizontal" });
+    const out = rankSwapCandidates([...ALL, dip], pushUp, null);
+
+    expect(reasonOf(out, dip.id)).toBe("same_pattern");
+  });
+
+  it("falls back to the push/pull family when the pattern has nothing else", () => {
+    const out = rankSwapCandidates(ALL, pullUp, null);
+
+    // `pull_horizontal` is not `pull_vertical`, but it is the same family — which is what makes
+    // the tail of the vertical-pull ladder reachable at all.
+    expect(reasonOf(out, tableRow.id)).toBe("easier");
+    expect(reasonOf(out, pushUp.id)).toBeNull();
+  });
+
+  it("still ranks a movement that declares no pattern", () => {
+    const unclassified = makeExercise({ id: 8, enName: "Nap", prerequisiteExerciseId: 1 });
+    const out = rankSwapCandidates([...ALL, unclassified], unclassified, null);
+
+    expect(reasonOf(out, tableRow.id)).toBe("easier");
+    expect(out).toHaveLength(ALL.length);
+  });
+
+  it("survives a prerequisite cycle in the seed rather than hanging a screen", () => {
+    const a = makeExercise({ id: 20, enName: "A", prerequisiteExerciseId: 21 });
+    const b = makeExercise({ id: 21, enName: "B", prerequisiteExerciseId: 20 });
+
+    const out = rankSwapCandidates([a, b], a, null);
+    expect(out.map((c) => c.exercise.id)).toEqual([21]);
   });
 });

--- a/__tests__/targets.test.ts
+++ b/__tests__/targets.test.ts
@@ -1,4 +1,4 @@
-import { Difficulty, generateTarget } from "@/db/targets";
+import { Difficulty, formatTarget, generateTarget } from "@/db/targets";
 
 describe("generateTarget", () => {
   it("scales reps by user level (easy < medium < hard)", () => {
@@ -57,5 +57,14 @@ describe("generateTarget", () => {
       const reps = { type: "reps" as const, min: 10, max: 20 };
       expect(generateTarget(reps, Difficulty.Medium, 60).value).toBe(15);
     });
+  });
+});
+
+describe("formatTarget", () => {
+  // One source for these words: the session's ghost line has to read the same as the target
+  // above it, and it used to live privately on the quest screen.
+  test("names the unit the slot is measured in", () => {
+    expect(formatTarget({ type: "reps", value: 12 })).toBe("12 reps");
+    expect(formatTarget({ type: "time", value: 30 })).toBe("30s");
   });
 });

--- a/app/(tabs)/quests/[id].tsx
+++ b/app/(tabs)/quests/[id].tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Dumbbell, Pencil, Sparkles } from "@tamagui/lucide-icons";
+import { ChevronLeft, Dumbbell, Pencil, Repeat, Sparkles } from "@tamagui/lucide-icons";
 import { Image } from "expo-image";
 import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import type { TFunction } from "i18next";
@@ -15,9 +15,11 @@ import { Card } from "@/components/common/Card";
 import { Skeleton, SkeletonCard } from "@/components/common/Skeleton";
 import { Tag } from "@/components/common/Tag";
 import { useToast } from "@/components/common/Toast";
+import { ExercisePickerSheet } from "@/components/quests/ExercisePickerSheet";
 import { QuestConfigCard } from "@/components/quests/QuestConfigCard";
 import { getExerciseThumb, getQuestAsset } from "@/constants/assetMap";
 import { getQuestColorTokensFromQuest } from "@/constants/exerciseColors";
+import { rankSwapCandidates, type SwapReason } from "@/constants/exerciseFilters";
 import {
   applyQuestConfig,
   Difficulty,
@@ -25,16 +27,20 @@ import {
   formatDurationEstimate,
   getQuestById,
   getQuestConfig,
+  indexExercises,
   isUserQuest,
   type QuestConfig,
   saveQuestConfig,
 } from "@/db";
 import { getAdventureStepNarrative } from "@/db/adventures-narrative";
 import { EQUIPMENT_LABELS } from "@/db/equipment";
+import { type Exercise, listExercises } from "@/db/exercises";
 import { MUSCLE_LABELS } from "@/db/muscles";
+import { preferences } from "@/db/preferences";
 import { getCached } from "@/db/queryCache";
-import type { Quest, Target } from "@/db/quests";
-import type { DifficultyCode } from "@/db/schema";
+import type { Quest } from "@/db/quests";
+import type { DifficultyCode, EquipmentCode } from "@/db/schema";
+import { formatTarget } from "@/db/targets";
 import { computeSessionXp } from "@/db/xp";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
@@ -56,11 +62,39 @@ function resolveExerciseImage(path?: string | null): ImageSourcePropType | null 
   return path.startsWith("http") ? { uri: path } : getExerciseThumb(path);
 }
 
-// "reps" reads fine in French too — see the "reps"/"config_reps" locale keys, which are
-// the same word in both languages — so there is no per-language branch here.
-function formatTarget(target: Target) {
-  if (target.type === "time") return `${target.value}s`;
-  return `${target.value} reps`;
+/** Stable empty list, so the sheet's props do not change identity on every render. */
+const EMPTY_CANDIDATES: ReturnType<typeof rankSwapCandidates> = [];
+
+/**
+ * Why a substitute is offered, in one line under the muscles — the slot `ExerciseRow` already
+ * keeps for the catalogue's ladder marker. One caption, never a row of badges: a difficulty chip
+ * and a progress bar per row were both refused on this component for the catalogue, and a wall of
+ * labels would be no kinder here.
+ */
+function swapReasonLabel(reason: SwapReason | null | undefined, t: TFunction): string | null {
+  if (reason === "easier") return t("quests.swap_reason_easier", "An easier rung");
+  if (reason === "harder") return t("quests.swap_reason_harder", "A harder rung");
+  if (reason === "same_pattern") return t("quests.swap_reason_pattern", "Same movement");
+  if (reason === "same_family") return t("quests.swap_reason_family", "Same family");
+  return null;
+}
+
+/**
+ * `ExerciseRow` drops `caption` straight into a `YStack`, so it has to be an element — a bare
+ * string throws "Text strings must be rendered within a <Text> component" at runtime, which
+ * neither `tsc` nor the test suite can see (`caption` is typed `ReactNode`, and a string is one).
+ * Same shape as the catalogue's `LeadsToCaption`.
+ */
+function SwapCaption({ reason }: { reason: SwapReason | null | undefined }) {
+  const { t } = useTranslation();
+  const label = swapReasonLabel(reason, t);
+  if (!label) return null;
+
+  return (
+    <Text fontSize={12} fontWeight="700" color="$primaryText" numberOfLines={1}>
+      {label}
+    </Text>
+  );
 }
 
 function levelLabel(level: Difficulty, t: TFunction) {
@@ -147,6 +181,13 @@ export default function QuestDetails() {
     const cached = questId != null ? getCached<Quest>(`quest:${questId}:${initialLevel}`) : null;
     return cached ? { status: "ready", quest: cached } : { status: "loading", quest: null };
   });
+  // The catalogue and the hero's kit: what a substitution picks from, and how it is ordered.
+  // Loaded with the quest rather than in their own effect, so a swapped slot never paints its
+  // original movement for a frame first.
+  const [catalogue, setCatalogue] = useState<Exercise[]>([]);
+  const [owned, setOwned] = useState<ReadonlySet<EquipmentCode> | null>(null);
+  /** The `quest_exercises` row whose picker is open, if any. */
+  const [swapFor, setSwapFor] = useState<number | null>(null);
   const [narrative, setNarrative] = useState<string | null>(null);
   const [showNarrative, setShowNarrative] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
@@ -163,7 +204,11 @@ export default function QuestDetails() {
     async (id: number, nextLevel: Difficulty) => {
       setState((s) => ({ status: "loading", quest: s.quest }));
       try {
-        const quest = await getQuestById(id, nextLevel);
+        const [quest, exercises, ownedList] = await Promise.all([
+          getQuestById(id, nextLevel),
+          listExercises(),
+          preferences.getOwnedEquipment(),
+        ]);
         if (!quest) {
           setState({
             status: "error",
@@ -172,6 +217,9 @@ export default function QuestDetails() {
           });
           return;
         }
+        setCatalogue(exercises);
+        // null means the question was never answered — "allow everything", as everywhere else.
+        setOwned(ownedList === null ? null : new Set(ownedList));
         setState({ status: "ready", quest });
       } catch (e) {
         reportError("quest.load", e);
@@ -252,13 +300,31 @@ export default function QuestDetails() {
     updateConfig({ level: config.level });
   }, [config.level, updateConfig]);
 
+  const applySwap = useCallback(
+    (questExerciseId: number, exercise: Exercise) => {
+      // The target override goes with the movement it was tuned for: "20" carried from push-ups
+      // onto a one-arm push-up is a bad prescription, and a swap is the hero saying this movement
+      // is not right for them. Dropped here rather than in `applyQuestConfig`, which stays a pure
+      // projection — `targets[id]` must never mean "a value for a movement no longer in this slot".
+      const { [String(questExerciseId)]: _replaced, ...targets } = config.targets ?? {};
+
+      updateConfig({
+        ...config,
+        targets,
+        swaps: { ...config.swaps, [String(questExerciseId)]: exercise.id },
+      });
+      setSwapFor(null);
+    },
+    [config, updateConfig],
+  );
+
   // Everything below — the estimate, the XP preview, the session that gets started — reads the
   // configured quest, so the numbers on screen are the numbers that will run. Memoized: this
   // used to run in the render body, so any unrelated re-render rebuilt the whole quest object
   // and re-ran the color/duration/XP pipeline.
   const derived = useMemo(() => {
     if (!state.quest) return null;
-    const quest = applyQuestConfig(state.quest, config);
+    const quest = applyQuestConfig(state.quest, config, indexExercises(catalogue));
     const estimatedSeconds = estimateQuestSeconds(quest);
     return {
       quest,
@@ -272,7 +338,16 @@ export default function QuestDetails() {
         userLevel: level as unknown as DifficultyCode,
       }),
     };
-  }, [state.quest, config, language, level]);
+  }, [state.quest, config, language, level, catalogue]);
+
+  // The slot being replaced, and what can go in it. Ranked here rather than inside the sheet:
+  // the sheet renders the order it is given, which is what lets the editor and this screen share
+  // it without a mode flag.
+  const swapSlot = derived?.quest.exercises.find((qex) => qex.id === swapFor) ?? null;
+  const swapCandidates = swapSlot
+    ? rankSwapCandidates(catalogue, swapSlot.exercise, owned)
+    : EMPTY_CANDIDATES;
+  const swapReasons = new Map(swapCandidates.map((c) => [c.exercise.id, c.reason] as const));
 
   // Thumbnails resolved once per quest — resolveExerciseImage (a split+regex asset lookup)
   // used to run twice per thumb on every render: once to filter, once to display.
@@ -532,6 +607,7 @@ export default function QuestDetails() {
               language={language}
               onChange={updateConfig}
               onReset={resetConfig}
+              onSwap={setSwapFor}
             />
           ) : null}
 
@@ -609,6 +685,21 @@ export default function QuestDetails() {
                         </Paragraph>
 
                         <XStack gap="$2" flexWrap="wrap" pt="$2">
+                          {/* What the hero did on this movement last time, in the slot's own unit.
+                              Here rather than in the config card's steppers: that card is folded
+                              shut by default, and this is the row the hero is already reading. */}
+                          {qex.ghost ? (
+                            <Tag
+                              label={t("quests.ghost_last", {
+                                value: formatTarget({
+                                  type: qex.target.type,
+                                  value: qex.ghost.last,
+                                }),
+                                defaultValue: `Last: ${qex.ghost.last}`,
+                              })}
+                              tone="secondary"
+                            />
+                          ) : null}
                           <Tag
                             label={
                               EQUIPMENT_LABELS[qex.exercise.equipment]?.[language] ??
@@ -671,6 +762,26 @@ export default function QuestDetails() {
             </Text>
           </AppButton>
         </YStack>
+      ) : null}
+
+      {swapSlot ? (
+        <ExercisePickerSheet
+          exercises={swapCandidates.map((c) => c.exercise)}
+          // The movement that is there now: the row wears the picker's "already picked" outline,
+          // which reads correctly as "this is the one you have".
+          pickedIds={[swapSlot.exercise.id]}
+          language={language}
+          open
+          onOpenChange={(next) => {
+            if (!next) setSwapFor(null);
+          }}
+          title={t("quests.swap_exercise", "Replace this movement")}
+          onPick={(exercise) => applySwap(swapSlot.id, exercise)}
+          closeOnPick
+          pickAction={<Repeat size={20} color="$primaryText" strokeWidth={2.5} />}
+          captionFor={(exercise) => <SwapCaption reason={swapReasons.get(exercise.id)} />}
+          bottomInset={insets.bottom}
+        />
       ) : null}
 
       <NarrativeModal

--- a/app/(tabs)/quests/edit.tsx
+++ b/app/(tabs)/quests/edit.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, Trash2, X } from "@tamagui/lucide-icons";
+import { ChevronLeft, Plus, Trash2, X } from "@tamagui/lucide-icons";
 import { Image } from "expo-image";
 import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -93,6 +93,7 @@ export default function QuestEditor() {
   const [rest, setRest] = useState(DEFAULT_REST);
   const [roundRest, setRoundRest] = useState(DEFAULT_REST);
   const [picked, setPicked] = useState<PickedExercise[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const nextUid = useRef(0);
   // The absolute save bar overlapped the "add an exercise" button by ~75px, so taps meant for
@@ -486,11 +487,26 @@ export default function QuestEditor() {
             );
           })}
 
+          {/* The trigger lives here, not in the sheet: its label names *this* screen's action,
+              and substitution opens the same sheet from a row with a different one. */}
+          <AppButton
+            variant="outline"
+            icon={<Plus size={20} color="$text" strokeWidth={2.5} />}
+            onPress={() => setPickerOpen(true)}
+            accessibilityLabel={t("quests.editor_add_exercise", "Add an exercise")}
+          >
+            {t("quests.editor_add_exercise", "Add an exercise")}
+          </AppButton>
+
           <ExercisePickerSheet
             exercises={exercises}
             pickedIds={pickedIds}
             language={language}
-            onAdd={addExercise}
+            open={pickerOpen}
+            onOpenChange={setPickerOpen}
+            title={t("quests.editor_add_exercise", "Add an exercise")}
+            onPick={addExercise}
+            pickAction={<Plus size={20} color="$primaryText" strokeWidth={2.5} />}
             bottomInset={insets.bottom}
           />
         </YStack>

--- a/components/quests/ExercisePickerSheet.tsx
+++ b/components/quests/ExercisePickerSheet.tsx
@@ -1,4 +1,5 @@
-import { Check, Plus, Search, X } from "@tamagui/lucide-icons";
+import { Check, Search, X } from "@tamagui/lucide-icons";
+import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Platform, Pressable } from "react-native";
@@ -17,6 +18,11 @@ import type { AppLanguage } from "@/stores/settings";
 const EMPTY_LADDER: ReadonlyMap<number, unknown> = new Map();
 
 type Props = {
+  /**
+   * Rendered in the order given — the caller decides what "best first" means. The editor passes
+   * the catalogue as it comes; a substitution passes it ranked. Keeping the ordering out here is
+   * what lets one sheet serve both without growing a mode.
+   */
   exercises: Exercise[];
   /**
    * Already in the quest, one entry per pick. Shown as a count on the row, never filtered out:
@@ -25,15 +31,39 @@ type Props = {
    */
   pickedIds: number[];
   language: AppLanguage;
-  onAdd: (exercise: Exercise) => void;
+  /** Controlled: the trigger belongs to the screen, because its label names the screen's action. */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  onPick: (exercise: Exercise) => void;
+  /** Adding builds a list, so the sheet stays open; replacing is one decision, so it closes. */
+  closeOnPick?: boolean;
+  /** The row's right-hand affordance — a `+` on an add, a swap glyph on a replace. */
+  pickAction: ReactNode;
+  /** A third line per row, e.g. why a substitute is being offered. */
+  captionFor?: (exercise: Exercise) => ReactNode;
   bottomInset: number;
 };
 
-/** The sheet stays open after each pick, so building a five-move quest is five taps, not five sheets. */
-export function ExercisePickerSheet({ exercises, pickedIds, language, onAdd, bottomInset }: Props) {
+/**
+ * The catalogue as a picker. Shared by the quest editor, where picking repeatedly builds a quest,
+ * and by substitution, where one pick replaces one slot.
+ */
+export function ExercisePickerSheet({
+  exercises,
+  pickedIds,
+  language,
+  open,
+  onOpenChange,
+  title,
+  onPick,
+  closeOnPick = false,
+  pickAction,
+  captionFor,
+  bottomInset,
+}: Props) {
   const { t } = useTranslation();
   const reducedMotion = useReducedMotion();
-  const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
   // Android reports a 0 bottom inset even where the system gesture area eats taps.
@@ -42,9 +72,9 @@ export function ExercisePickerSheet({ exercises, pickedIds, language, onAdd, bot
   // Closing resets the search: it used to survive, so reopening showed a list still filtered by
   // a word the hero had long forgotten typing, with no visible cue why most exercises were gone.
   const close = useCallback(() => {
-    setOpen(false);
+    onOpenChange(false);
     setSearch("");
-  }, []);
+  }, [onOpenChange]);
 
   // The catalogue's filter, with only the search facet set: one name-matching rule for both
   // screens, and it goes through `localizedName` rather than a fifteenth inline ternary.
@@ -68,123 +98,116 @@ export function ExercisePickerSheet({ exercises, pickedIds, language, onAdd, bot
   );
 
   return (
-    <>
-      <AppButton
-        variant="outline"
-        icon={<Plus size={20} color="$text" strokeWidth={2.5} />}
-        onPress={() => setOpen(true)}
-        accessibilityLabel={t("quests.editor_add_exercise", "Add an exercise")}
-      >
-        {t("quests.editor_add_exercise", "Add an exercise")}
-      </AppButton>
-
-      <Sheet
-        modal
-        open={open}
-        onOpenChange={(next: boolean) => (next ? setOpen(true) : close())}
-        snapPoints={[85]}
-        dismissOnSnapToBottom
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={(next: boolean) => (next ? onOpenChange(true) : close())}
+      snapPoints={[85]}
+      dismissOnSnapToBottom
+      transition={reducedMotion ? undefined : "quick"}
+      zIndex={100_000}
+    >
+      <Sheet.Overlay
+        bg="rgba(0,0,0,0.5)"
         transition={reducedMotion ? undefined : "quick"}
-        zIndex={100_000}
-      >
-        <Sheet.Overlay
-          bg="rgba(0,0,0,0.5)"
-          transition={reducedMotion ? undefined : "quick"}
-          enterStyle={{ opacity: 0 }}
-          exitStyle={{ opacity: 0 }}
-        />
-        <Sheet.Handle bg="$borderStrong" />
-        {/* No flex={1}: the snap point already sets the frame's height, and letting it also grow
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+      />
+      <Sheet.Handle bg="$borderStrong" />
+      {/* No flex={1}: the snap point already sets the frame's height, and letting it also grow
             left the frame stranded mid-screen after a close — visible, but with open already
             false, so nothing in it answered. VillageDetailSheet, which works, has no flex here. */}
-        <Sheet.Frame bg="$surface">
-          <YStack px="$4" pt="$4" pb="$3" gap="$3">
-            <XStack items="center" justify="space-between">
-              <Text fontWeight="700" fontSize={18} color="$text">
-                {t("quests.editor_add_exercise", "Add an exercise")}
-              </Text>
-              <Pressable
-                hitSlop={12}
-                accessibilityRole="button"
-                accessibilityLabel={t("common.close", "Close")}
-                onPress={close}
-              >
-                <X size={20} color="$textSecondary" />
-              </Pressable>
-            </XStack>
-
-            <XStack items="center" gap="$2">
-              <Input
-                flex={1}
-                value={search}
-                onChangeText={setSearch}
-                placeholder={t("quests.editor_search", "Search")}
-                bg="$background"
-                borderColor="$borderStrong"
-                color="$text"
-              />
-              <Search size={18} color="$textSecondary" />
-            </XStack>
-          </YStack>
-
-          <Sheet.ScrollView flex={1} px="$4" keyboardShouldPersistTaps="handled">
-            <YStack gap="$2" pb="$3">
-              {results.map((exercise) => {
-                const picked = countByExerciseId.get(exercise.id) ?? 0;
-                const name = localizedName(exercise, language);
-
-                return (
-                  <ExerciseRow
-                    key={exercise.id}
-                    exercise={exercise}
-                    language={language}
-                    thumb={assetByExerciseId.get(exercise.id)}
-                    borderColor={picked > 0 ? "$primaryText" : "$borderStrong"}
-                    accessibilityLabel={
-                      picked > 0
-                        ? `${name}, ${t("quests.editor_added_count", { count: picked })}`
-                        : name
-                    }
-                    onPress={() => onAdd(exercise)}
-                    trailing={
-                      <>
-                        {picked > 0 ? (
-                          <XStack
-                            items="center"
-                            gap="$1"
-                            px="$2"
-                            py="$1"
-                            rounded="$10"
-                            bg="$surface"
-                            borderWidth={1}
-                            borderColor="$primaryText"
-                          >
-                            <Check size={14} color="$primaryText" strokeWidth={3} />
-                            <Text fontSize={12} fontWeight="700" color="$primaryText">
-                              {picked}
-                            </Text>
-                          </XStack>
-                        ) : null}
-                        <Plus size={20} color="$primaryText" strokeWidth={2.5} />
-                      </>
-                    }
-                  />
-                );
-              })}
-
-              {results.length === 0 ? (
-                <Text fontSize={14} color="$textSecondary" p="$3">
-                  {t("quests.editor_no_results", "No exercise matches that.")}
-                </Text>
-              ) : null}
-            </YStack>
-          </Sheet.ScrollView>
-
-          <XStack p="$4" pb={bottomPad} borderTopWidth={1} borderColor="$borderStrong">
-            <AppButton onPress={close}>{t("common.done", "Done")}</AppButton>
+      <Sheet.Frame bg="$surface">
+        <YStack px="$4" pt="$4" pb="$3" gap="$3">
+          <XStack items="center" justify="space-between">
+            <Text fontWeight="700" fontSize={18} color="$text">
+              {title}
+            </Text>
+            <Pressable
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel={t("common.close", "Close")}
+              onPress={close}
+            >
+              <X size={20} color="$textSecondary" />
+            </Pressable>
           </XStack>
-        </Sheet.Frame>
-      </Sheet>
-    </>
+
+          <XStack items="center" gap="$2">
+            <Input
+              flex={1}
+              value={search}
+              onChangeText={setSearch}
+              placeholder={t("quests.editor_search", "Search")}
+              bg="$background"
+              borderColor="$borderStrong"
+              color="$text"
+            />
+            <Search size={18} color="$textSecondary" />
+          </XStack>
+        </YStack>
+
+        <Sheet.ScrollView flex={1} px="$4" keyboardShouldPersistTaps="handled">
+          <YStack gap="$2" pb="$3">
+            {results.map((exercise) => {
+              const picked = countByExerciseId.get(exercise.id) ?? 0;
+              const name = localizedName(exercise, language);
+
+              return (
+                <ExerciseRow
+                  key={exercise.id}
+                  exercise={exercise}
+                  language={language}
+                  thumb={assetByExerciseId.get(exercise.id)}
+                  borderColor={picked > 0 ? "$primaryText" : "$borderStrong"}
+                  accessibilityLabel={
+                    picked > 0
+                      ? `${name}, ${t("quests.editor_added_count", { count: picked })}`
+                      : name
+                  }
+                  caption={captionFor?.(exercise)}
+                  onPress={() => {
+                    onPick(exercise);
+                    if (closeOnPick) close();
+                  }}
+                  trailing={
+                    <>
+                      {picked > 0 ? (
+                        <XStack
+                          items="center"
+                          gap="$1"
+                          px="$2"
+                          py="$1"
+                          rounded="$10"
+                          bg="$surface"
+                          borderWidth={1}
+                          borderColor="$primaryText"
+                        >
+                          <Check size={14} color="$primaryText" strokeWidth={3} />
+                          <Text fontSize={12} fontWeight="700" color="$primaryText">
+                            {picked}
+                          </Text>
+                        </XStack>
+                      ) : null}
+                      {pickAction}
+                    </>
+                  }
+                />
+              );
+            })}
+
+            {results.length === 0 ? (
+              <Text fontSize={14} color="$textSecondary" p="$3">
+                {t("quests.editor_no_results", "No exercise matches that.")}
+              </Text>
+            ) : null}
+          </YStack>
+        </Sheet.ScrollView>
+
+        <XStack p="$4" pb={bottomPad} borderTopWidth={1} borderColor="$borderStrong">
+          <AppButton onPress={close}>{t("common.done", "Done")}</AppButton>
+        </XStack>
+      </Sheet.Frame>
+    </Sheet>
   );
 }

--- a/components/quests/QuestConfigCard.tsx
+++ b/components/quests/QuestConfigCard.tsx
@@ -1,9 +1,15 @@
-import { ChevronDown, ChevronUp, RotateCcw, SlidersHorizontal } from "@tamagui/lucide-icons";
+import {
+  ChevronDown,
+  ChevronUp,
+  Repeat,
+  RotateCcw,
+  SlidersHorizontal,
+} from "@tamagui/lucide-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Separator, Text, XStack, YStack } from "tamagui";
 
-import { AppButton } from "@/components/common/AppButton";
+import { AppButton, AppIconButton } from "@/components/common/AppButton";
 import { Card } from "@/components/common/Card";
 import { Stepper } from "@/components/common/Stepper";
 import { Tag } from "@/components/common/Tag";
@@ -21,9 +27,11 @@ type Props = {
   language: AppLanguage;
   onChange: (next: QuestConfig) => void;
   onReset: () => void;
+  /** Opens the picker for one slot. Lives here because a substitution *is* a config override. */
+  onSwap: (questExerciseId: number) => void;
 };
 
-export function QuestConfigCard({ quest, config, language, onChange, onReset }: Props) {
+export function QuestConfigCard({ quest, config, language, onChange, onReset, onSwap }: Props) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const modified = hasQuestOverrides(config);
@@ -96,21 +104,30 @@ export function QuestConfigCard({ quest, config, language, onChange, onReset }: 
             <Separator borderColor="$borderStrong" />
 
             {quest.exercises.map((qex) => (
-              <Stepper
-                key={qex.id}
-                label={language === "fr" ? qex.exercise.frName : qex.exercise.enName}
-                hint={
-                  qex.target.type === "time"
-                    ? t("quests.config_seconds", "Seconds")
-                    : t("quests.config_reps", "Reps")
-                }
-                value={qex.target.value}
-                min={TARGET_RANGE.min}
-                max={TARGET_RANGE.max}
-                step={qex.target.type === "time" ? REST_STEP : 1}
-                suffix={qex.target.type === "time" ? "s" : ""}
-                onChange={(value) => setTarget(qex.id, value)}
-              />
+              <XStack key={qex.id} items="center" gap="$2">
+                <YStack flex={1}>
+                  <Stepper
+                    label={language === "fr" ? qex.exercise.frName : qex.exercise.enName}
+                    hint={
+                      qex.target.type === "time"
+                        ? t("quests.config_seconds", "Seconds")
+                        : t("quests.config_reps", "Reps")
+                    }
+                    value={qex.target.value}
+                    min={TARGET_RANGE.min}
+                    max={TARGET_RANGE.max}
+                    step={qex.target.type === "time" ? REST_STEP : 1}
+                    suffix={qex.target.type === "time" ? "s" : ""}
+                    onChange={(value) => setTarget(qex.id, value)}
+                  />
+                </YStack>
+                <AppIconButton
+                  accessibilityLabel={t("quests.swap_exercise", "Replace this movement")}
+                  onPress={() => onSwap(qex.id)}
+                >
+                  <Repeat size={18} color="$text" strokeWidth={2.5} />
+                </AppIconButton>
+              </XStack>
             ))}
 
             {modified ? (

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -13,6 +13,7 @@ import {
   getExerciseBgRawForSessionStep,
 } from "@/constants/exerciseColors";
 import { critChance } from "@/db/bossFights";
+import { formatTarget } from "@/db/targets";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { formatOvertime, formatTime, useSessionTimer } from "@/hooks/useSessionTimer";
@@ -52,6 +53,7 @@ export function ActiveExerciseView() {
   if (!quest || !currentEx) return null;
 
   const isTimeBased = currentEx.target.type === "time";
+  const ghost = currentEx.ghost;
 
   const exerciseName = localizedName(currentEx.exercise, language);
   const exerciseDescription =
@@ -437,6 +439,24 @@ export function ActiveExerciseView() {
                 {t("session.keep_going_hint")}
               </Text>
             )}
+
+            {/* What the hero already did on this movement. Outside the reps/time ternary above so
+                one line serves both units, and read straight off the quest — `getQuestById` put it
+                there, so nothing is queried mid-workout and a recovered session keeps it.
+                Two phrasings: on a first-ever session `last` and `best` are the same number, and
+                "last time 12 · best 12" reads like a bug. */}
+            {ghost ? (
+              <Text fontSize={12} color="$textSecondary" style={{ textAlign: "center" }}>
+                {ghost.best > ghost.last
+                  ? t("session.ghost_last_best", {
+                      last: formatTarget({ type: currentEx.target.type, value: ghost.last }),
+                      best: formatTarget({ type: currentEx.target.type, value: ghost.best }),
+                    })
+                  : t("session.ghost_last", {
+                      value: formatTarget({ type: currentEx.target.type, value: ghost.last }),
+                    })}
+              </Text>
+            ) : null}
           </YStack>
         </ScrollView>
 

--- a/constants/exerciseFilters.ts
+++ b/constants/exerciseFilters.ts
@@ -1,5 +1,6 @@
 import type { Exercise } from "@/db/exercises";
-import type { EquipmentCode, MovementPattern, MuscleCode } from "@/db/schema";
+import { PULL_PATTERNS, PUSH_PATTERNS } from "@/db/patterns";
+import type { DifficultyCode, EquipmentCode, MovementPattern, MuscleCode } from "@/db/schema";
 import { localizedName } from "@/src/i18n/localized";
 import type { AppLanguage } from "@/stores/settings";
 
@@ -71,4 +72,117 @@ export function filterExercises(
       matchesOne(filters.equipment, e.equipment) &&
       matchesOne(filters.patterns, e.pattern),
   );
+}
+
+/**
+ * Why a movement is being offered as a replacement. `null` means "nothing in common" — the tail
+ * of the list, reachable but never explained.
+ */
+export type SwapReason = "easier" | "harder" | "same_pattern" | "same_family";
+
+export type SwapCandidate = { exercise: Exercise; reason: SwapReason | null };
+
+const DIFFICULTY_RANK: Record<DifficultyCode, number> = { easy: 0, medium: 1, hard: 2 };
+
+/** Owned, or free, or the question was never asked — `null` means "allow everything". */
+function isAffordable(exercise: Exercise, owned: ReadonlySet<EquipmentCode> | null): boolean {
+  return owned === null || exercise.equipment === "none" || owned.has(exercise.equipment);
+}
+
+/**
+ * Every rung of `current`'s ladder, in both directions, transitively.
+ *
+ * Transitively, and this is the part that decides whether the feature works at all. Verified
+ * against the seeded catalogue: `pull_vertical` holds 6 movements and **all 6 need a bar**, so a
+ * hero without one has no same-pattern option whatsoever on a Pull-ups slot. The ladder is the
+ * way out — but only walked to its end, because it takes six rungs to reach the first
+ * equipment-free movement, and it crosses into `pull_horizontal` on the way (Dead Hang's
+ * prerequisite is an Inverted Row). A one-step walk returns another movement on a bar.
+ *
+ * `seen` guards a seed cycle rather than trusting the data: a prerequisite loop would hang the
+ * app on a screen, which is a bad place to discover a content mistake.
+ */
+function ladderOf(
+  exercises: Exercise[],
+  current: Exercise,
+): Map<number, Extract<SwapReason, "easier" | "harder">> {
+  const byId = new Map(exercises.map((e) => [e.id, e] as const));
+  const leadsTo = buildLeadsTo(exercises);
+  const found = new Map<number, Extract<SwapReason, "easier" | "harder">>();
+  const seen = new Set<number>([current.id]);
+
+  let down = byId.get(current.prerequisiteExerciseId ?? -1);
+  while (down && !seen.has(down.id)) {
+    seen.add(down.id);
+    found.set(down.id, "easier");
+    down = byId.get(down.prerequisiteExerciseId ?? -1);
+  }
+
+  let up = leadsTo.get(current.id);
+  while (up && !seen.has(up.id)) {
+    seen.add(up.id);
+    found.set(up.id, "harder");
+    up = leadsTo.get(up.id);
+  }
+
+  return found;
+}
+
+function familyOf(pattern: MovementPattern | null): readonly MovementPattern[] | null {
+  if (pattern === null) return null;
+  if (PUSH_PATTERNS.includes(pattern)) return PUSH_PATTERNS;
+  if (PULL_PATTERNS.includes(pattern)) return PULL_PATTERNS;
+  return null;
+}
+
+/**
+ * What the hero can put in this slot instead, best first.
+ *
+ * Four tiers — the ladder, then the same pattern, then the same push/pull family, then the rest —
+ * and **nothing is ever removed**. Equipment the hero does not own sinks to the bottom of its tier
+ * rather than disappearing: `getOwnedEquipment()` returns `null` until the question is answered,
+ * a kitchen table is not fitness gear, and the hero is the only one who knows what is in the room.
+ */
+export function rankSwapCandidates(
+  exercises: Exercise[],
+  current: Exercise,
+  owned: ReadonlySet<EquipmentCode> | null,
+): SwapCandidate[] {
+  const ladder = ladderOf(exercises, current);
+  const family = familyOf(current.pattern);
+
+  const tier = (e: Exercise): number => {
+    if (ladder.has(e.id)) return 0;
+    if (current.pattern !== null && e.pattern === current.pattern) return 1;
+    if (family !== null && e.pattern !== null && family.includes(e.pattern)) return 2;
+    return 3;
+  };
+
+  const reason = (e: Exercise): SwapReason | null => {
+    const rung = ladder.get(e.id);
+    if (rung) return rung;
+    if (current.pattern !== null && e.pattern === current.pattern) return "same_pattern";
+    if (family !== null && e.pattern !== null && family.includes(e.pattern)) return "same_family";
+    return null;
+  };
+
+  return exercises
+    .filter((e) => e.id !== current.id)
+    .map((e) => ({ exercise: e, tier: tier(e), reason: reason(e) }))
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+
+      const affordable =
+        Number(isAffordable(b.exercise, owned)) - Number(isAffordable(a.exercise, owned));
+      if (affordable !== 0) return affordable;
+
+      const closeness =
+        Math.abs(DIFFICULTY_RANK[a.exercise.difficulty] - DIFFICULTY_RANK[current.difficulty]) -
+        Math.abs(DIFFICULTY_RANK[b.exercise.difficulty] - DIFFICULTY_RANK[current.difficulty]);
+      if (closeness !== 0) return closeness;
+
+      // Last resort so the order is stable between renders rather than dependent on input order.
+      return a.exercise.id - b.exercise.id;
+    })
+    .map(({ exercise, reason: why }) => ({ exercise, reason: why }));
 }

--- a/db/index.ts
+++ b/db/index.ts
@@ -40,6 +40,7 @@ export {
   clearQuestConfig,
   getQuestConfig,
   hasQuestOverrides,
+  indexExercises,
   REST_RANGE,
   ROUNDS_RANGE,
   saveQuestConfig,

--- a/db/personalRecords.ts
+++ b/db/personalRecords.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, max, sql } from "drizzle-orm";
+import { desc, eq, inArray, max, sql } from "drizzle-orm";
 import { db, schema } from "./client";
 import type { QuestTargetType } from "./schema";
 
@@ -87,82 +87,97 @@ export async function getMostXpSession(): Promise<PersonalRecord | null> {
 }
 
 /**
- * Best single result for an exercise, in one unit.
+ * What the hero has already done on a movement, in that movement's own unit.
  *
- * The unit is not optional: reps and seconds share the `resultValue` column, so pooling them
- * makes a 60 s hold outrank every rep set the hero has ever done on the same movement.
+ * `last` is the best set of the most recent session, not its last row: a 12/10/8 quest would
+ * otherwise report 8 as the thing to beat — a floor the hero cleared twice on the way down. It is
+ * the rule `checkForNewRecords` already applies below, so "what to beat" and "what the app
+ * celebrates" name the same number.
+ *
+ * ponytail: the session's best set, not the same round's. Matching `roundIndex` would compare
+ * round 3 against last time's round 3, which is truer and doubles the fold; do it if anyone
+ * reports the round-1 number feeling unreachable.
  */
-/** @legacy Meilleur résultat sur un exercice ; l'écran exercice calcule le sien. */
-export async function getExerciseMax(
-  exerciseId: number,
-  resultType: QuestTargetType = "reps",
-): Promise<PersonalRecord | null> {
-  const rows = await db
-    .select({
-      sessionId: completedExercises.sessionId,
-      resultValue: completedExercises.resultValue,
-      performedAt: completedExercises.performedAt,
-      enName: exercises.enName,
-      frName: exercises.frName,
-    })
-    .from(completedExercises)
-    .innerJoin(exercises, eq(exercises.id, completedExercises.exerciseId))
-    .where(
-      and(
-        eq(completedExercises.exerciseId, exerciseId),
-        eq(completedExercises.resultType, resultType),
-      ),
-    )
-    .orderBy(desc(completedExercises.resultValue))
-    .limit(1);
+export type ExerciseGhost = { last: number; best: number };
 
-  const best = rows[0];
-  if (!best) {
-    return null;
-  }
+/**
+ * Reps and seconds share `resultValue` and nothing in the column says which one it holds, so a
+ * 60 s hold pooled with rep sets reports itself as a rep record. The unit rides in the key —
+ * same composite `checkForNewRecords` folds on.
+ */
+export function ghostKey(exerciseId: number, type: QuestTargetType): string {
+  return `${exerciseId}:${type}`;
+}
 
-  return {
-    type: resultType === "time" ? "exercise_max_time" : "exercise_max_reps",
-    value: best.resultValue,
-    achievedAt: best.performedAt,
-    exerciseId,
-    exerciseName: { en: best.enName, fr: best.frName },
-    sessionId: best.sessionId,
-  };
+type SessionBest = ExerciseGhost & { at: number; sessionId: number };
+
+/**
+ * Two sessions finished in the same second share a timestamp, so the timestamp alone would leave
+ * "last time" up to row order. The id breaks the tie.
+ */
+function isNewerSession(a: SessionBest, b: SessionBest): boolean {
+  return a.at > b.at || (a.at === b.at && a.sessionId > b.sessionId);
 }
 
 /**
- * Longest logged hold per exercise, for a batch of exercises, in one query.
+ * The journal's answer for a batch of movements, in one query.
  *
- * `getExerciseMax` above answers for one exercise and joins the name and session for display.
- * Opening a quest needs neither, and needs the answer for every hold in it — one grouped read
- * instead of three round trips, because each is a synchronous SQLite call on the JS thread and
- * duplicates are paid in dropped frames (same reasoning as `shortLivedQuery`).
+ * Opening a quest needs this for every exercise in it, and each read is a synchronous SQLite call
+ * on the JS thread — duplicates are paid in dropped frames (same reasoning as `shortLivedQuery`).
+ * Movements with nothing logged are simply absent from the map.
  *
- * Exercises with no logged hold are simply absent from the map.
+ * Grouping by session first is what makes `last` mean "the best set of that evening": the two
+ * aggregates are independent on purpose, `best` being the session's best value and `at` its last
+ * set's time.
  */
-export async function getMaxHoldSeconds(exerciseIds: number[]): Promise<Map<number, number>> {
+export async function getExerciseHistory(
+  exerciseIds: number[],
+): Promise<Map<string, ExerciseGhost>> {
   if (exerciseIds.length === 0) return new Map();
 
   const rows = await db
     .select({
       exerciseId: completedExercises.exerciseId,
+      resultType: completedExercises.resultType,
+      sessionId: completedExercises.sessionId,
       best: max(completedExercises.resultValue),
+      at: max(completedExercises.performedAt),
     })
     .from(completedExercises)
-    .where(
-      and(
-        inArray(completedExercises.exerciseId, exerciseIds),
-        eq(completedExercises.resultType, "time"),
-      ),
-    )
-    .groupBy(completedExercises.exerciseId);
+    .where(inArray(completedExercises.exerciseId, exerciseIds))
+    .groupBy(
+      completedExercises.exerciseId,
+      completedExercises.resultType,
+      completedExercises.sessionId,
+    );
 
-  const byExercise = new Map<number, number>();
+  const byKey = new Map<string, SessionBest>();
+
   for (const r of rows) {
-    if (r.best != null && r.best > 0) byExercise.set(r.exerciseId, r.best);
+    if (r.best == null || r.best <= 0) continue;
+
+    // An aggregate does not go through the column's timestamp mapper on every driver, so accept
+    // both shapes rather than trusting one.
+    const at = r.at instanceof Date ? r.at.getTime() : Number(r.at ?? 0);
+    const row: SessionBest = { last: r.best, best: r.best, at, sessionId: r.sessionId };
+    const key = ghostKey(r.exerciseId, r.resultType);
+    const entry = byKey.get(key);
+
+    if (!entry) {
+      byKey.set(key, row);
+      continue;
+    }
+
+    entry.best = Math.max(entry.best, row.best);
+
+    if (isNewerSession(row, entry)) {
+      entry.last = row.last;
+      entry.at = row.at;
+      entry.sessionId = row.sessionId;
+    }
   }
-  return byExercise;
+
+  return new Map([...byKey].map(([key, v]) => [key, { last: v.last, best: v.best }]));
 }
 
 /**

--- a/db/questConfig.ts
+++ b/db/questConfig.ts
@@ -1,3 +1,4 @@
+import { type Exercise, listExercises } from "./exercises";
 import { deletePreference, getPreference, setPreference } from "./preferences";
 import { getQuestById, type Quest } from "./quests";
 import { Difficulty, type UserLevel } from "./targets";
@@ -20,6 +21,12 @@ export type QuestConfig = {
    * are possible; `applyQuestConfig` simply ignores ids the quest no longer has.
    */
   targets?: Record<string, number>;
+  /**
+   * quest_exercises row id -> the exercise the hero put in that slot instead. Same stale-key rule
+   * as `targets`, and the same reason it lives here rather than on the quest row: a substitution
+   * is this hero's, and the template is shared content.
+   */
+  swaps?: Record<string, number>;
 };
 
 export const ROUNDS_RANGE = { min: 1, max: 10 };
@@ -38,6 +45,22 @@ function isLevel(value: unknown): value is UserLevel {
 
 function readNumber(value: unknown, range: { min: number; max: number }): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? clamp(value, range) : undefined;
+}
+
+/**
+ * Not `readNumber`: its `clamp` would round a corrupt `3.7` into exercise id 4, which exists. An
+ * id is either an id or nothing — whether it still *names* an exercise is `applyQuestConfig`'s
+ * problem, exactly as with a stale `targets` key.
+ */
+function readSwaps(value: unknown): Record<string, number> | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+
+  const swaps: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "number" && Number.isInteger(raw) && raw > 0) swaps[key] = raw;
+  }
+
+  return Object.keys(swaps).length > 0 ? swaps : undefined;
 }
 
 function readTargets(value: unknown): Record<string, number> | undefined {
@@ -81,6 +104,9 @@ export function parseQuestConfig(raw: string | null): QuestConfig | null {
   const targets = readTargets(record.targets);
   if (targets !== undefined) config.targets = targets;
 
+  const swaps = readSwaps(record.swaps);
+  if (swaps !== undefined) config.swaps = swaps;
+
   return config;
 }
 
@@ -103,18 +129,38 @@ export function hasQuestOverrides(config: QuestConfig | null): boolean {
     config.rounds !== undefined ||
     config.restSeconds !== undefined ||
     config.roundRestSeconds !== undefined ||
-    Object.keys(config.targets ?? {}).length > 0
+    Object.keys(config.targets ?? {}).length > 0 ||
+    Object.keys(config.swaps ?? {}).length > 0
   );
+}
+
+/**
+ * The catalogue keyed by id, the shape `applyQuestConfig` wants. Exported so the quest screen
+ * builds it the same way Home does — the two must agree on what "this quest" means.
+ */
+export function indexExercises(exercises: Exercise[]): Record<number, Exercise> {
+  return Object.fromEntries(exercises.map((e) => [e.id, e] as const));
 }
 
 /**
  * The quest as this hero configured it. Pure so the estimate, the XP preview and the session all
  * read the same numbers: apply once, then everything downstream keeps working untouched.
+ *
+ * `exercisesById` is **required**, not optional, and that is the whole point. A substitution needs
+ * the replacement's full row, which this function has no way to fetch without going async and
+ * losing its purity — so the catalogue is threaded in. Optional, `loadConfiguredQuest` would keep
+ * compiling while silently ignoring every swap, and Home would start push-ups while the quest
+ * screen started dips. Required, that divergence is a compile error at every call site.
  */
-export function applyQuestConfig(quest: Quest, config: QuestConfig | null): Quest {
+export function applyQuestConfig(
+  quest: Quest,
+  config: QuestConfig | null,
+  exercisesById: Record<number, Exercise>,
+): Quest {
   if (!hasQuestOverrides(config) || !config) return quest;
 
   const targets = config.targets ?? {};
+  const swaps = config.swaps ?? {};
 
   return {
     ...quest,
@@ -122,8 +168,28 @@ export function applyQuestConfig(quest: Quest, config: QuestConfig | null): Ques
     restSeconds: config.restSeconds ?? quest.restSeconds,
     roundRestSeconds: config.roundRestSeconds ?? quest.roundRestSeconds,
     exercises: quest.exercises.map((qex) => {
-      const value = targets[String(qex.id)];
-      return value === undefined ? qex : { ...qex, target: { ...qex.target, value } };
+      const key = String(qex.id);
+      const swappedId = swaps[key];
+      const substitute = swappedId === undefined ? undefined : exercisesById[swappedId];
+      const value = targets[key];
+
+      if (substitute === undefined && value === undefined) return qex;
+
+      return {
+        ...qex,
+        ...(value === undefined ? {} : { target: { ...qex.target, value } }),
+        ...(substitute === undefined
+          ? {}
+          : {
+              exercise: substitute,
+              // `images` is the quest's own art *of the movement that used to be here*, off
+              // `quest_exercises.imagesJson`. Kept, the card illustrates the wrong exercise.
+              images: [],
+              // The ghost belongs to the slot's old movement too, and the substitute's own
+              // history is not in this object — better silent than wrong.
+              ghost: undefined,
+            }),
+      };
     }),
   };
 }
@@ -140,9 +206,12 @@ export function applyQuestConfig(quest: Quest, config: QuestConfig | null): Ques
 export async function loadConfiguredQuest(
   questId: number,
 ): Promise<{ quest: Quest; level: UserLevel } | null> {
-  const config = await getQuestConfig(questId);
+  // `listExercises()` is promise-cached, so the catalogue is free after the first read anywhere
+  // in the app — and it is what lets a swap resolve without this function knowing about screens.
+  const [config, exercises] = await Promise.all([getQuestConfig(questId), listExercises()]);
   const level = config?.level ?? Difficulty.Medium;
   const quest = await getQuestById(questId, level);
+  if (!quest) return null;
 
-  return quest ? { quest: applyQuestConfig(quest, config), level } : null;
+  return { quest: applyQuestConfig(quest, config, indexExercises(exercises)), level };
 }

--- a/db/quests.ts
+++ b/db/quests.ts
@@ -3,7 +3,7 @@ import { db, schema } from "./client";
 import { dayKey } from "./dates";
 import type { Exercise } from "./exercises";
 import { isMuscleCode } from "./muscles";
-import { getMaxHoldSeconds } from "./personalRecords";
+import { type ExerciseGhost, getExerciseHistory, ghostKey } from "./personalRecords";
 import { preferences, type TrainingLevel } from "./preferences";
 import { clearCached, setCached } from "./queryCache";
 import type { DifficultyCode, MuscleCode, QuestArchetype, QuestTargetType } from "./schema";
@@ -30,6 +30,16 @@ export interface QuestExercise {
 
   /** Target for this quest – either repetitions or seconds */
   target: Target;
+
+  /**
+   * What the hero has already done on this movement, in *this slot's* unit — the best set of
+   * their last session, and their all-time best. Absent when they have never trained it.
+   *
+   * It rides on the quest rather than living in the session store on purpose: `quest` is already
+   * inside `SavedSessionState`, so a session recovered after a crash keeps its ghosts with no
+   * second field to keep in sync, and the quest screen gets the same numbers from the same read.
+   */
+  ghost?: ExerciseGhost;
 }
 
 export type QuestTemplateExercise = {
@@ -422,12 +432,11 @@ export async function getQuestById(id: number, userLevel: UserLevel): Promise<Qu
   const first = rows[0];
   if (!first) return null;
 
-  // Holds are prescribed from the hero's own longest hold (60-75% of max), so read the records
-  // for this quest's time-based movements before building any target. One grouped query, and
-  // none at all for a quest that has no holds in it.
-  const maxHolds = await getMaxHoldSeconds([
-    ...new Set(rows.filter((r) => r.targetType === "time").map((r) => r.exId)),
-  ]);
+  // Two things come out of the journal here, in one grouped query: the longest hold, because a
+  // hold is prescribed from the hero's own maximum (60-75% of it), and the ghost every slot shows
+  // — what they did last time on this movement. Both are per (movement, unit), so one read
+  // answers both and nothing is fetched again mid-session.
+  const history = await getExerciseHistory([...new Set(rows.map((r) => r.exId))]);
 
   const quest: Quest = {
     id: first.questId,
@@ -474,7 +483,10 @@ export async function getQuestById(id: number, userLevel: UserLevel): Promise<Qu
           muscles: [],
         },
         images: safeParseImages(r.imagesJson),
-        target: generateTarget(base, userLevel, maxHolds.get(r.exId)),
+        target: generateTarget(base, userLevel, history.get(ghostKey(r.exId, "time"))?.best),
+        // In the slot's own unit: a movement trained both ways has two records, and showing the
+        // hold next to a rep target would be a number the hero cannot act on.
+        ghost: history.get(ghostKey(r.exId, r.targetType)),
       };
       byQuestExercise.set(r.qexId, qex);
       quest.exercises.push(qex);
@@ -627,6 +639,12 @@ export function questTrainingLevel(difficulties: DifficultyCode[]): TrainingLeve
  * equipment they do not have, and advanced quests for someone who said they are a beginner.
  * A "regular" hero still gets offered advanced work — that is a stretch, not a wall — and a
  * hero who skipped the onboarding question (`null`) is not filtered at all.
+ */
+/**
+ * ponytail: eligibility reads the template, so a quest the hero has swapped the barbell movement
+ * out of is still hidden from them. Half-serves the case substitution exists for. Folding saved
+ * swaps in means scanning `user_preferences` here, on a path Home hits on every mount — do it
+ * when someone reports the quest staying hidden after they fixed it.
  */
 export async function getEligibleQuestIds(): Promise<Set<number>> {
   const [ownedEquipment, trainingLevel, rows] = await Promise.all([

--- a/db/targets.ts
+++ b/db/targets.ts
@@ -19,6 +19,19 @@ export type Target = {
 };
 
 /**
+ * A target as the hero reads it. Lives here rather than on the quest screen because the session
+ * shows the same numbers — a ghost line saying "18" has to use the same words as the target above
+ * it, and two copies of this drift (see `localizedTitle()` in AGENTS.md, "one source per value").
+ *
+ * "reps" reads fine in French too — see the `reps`/`config_reps` locale keys, which are the same
+ * word in both languages — so there is no per-language branch here.
+ */
+export function formatTarget(target: Target): string {
+  if (target.type === "time") return `${target.value}s`;
+  return `${target.value} reps`;
+}
+
+/**
  * How much of a quest's prescribed range the hero actually gets. Also what a boss's HP pool is
  * scaled by — damage *is* the work you did, so a pool tuned at one level is unreachable at
  * another. One multiplier, both sides. See `db/bossFights.ts`.

--- a/locales/en.json
+++ b/locales/en.json
@@ -210,6 +210,12 @@
     "reward_xp": "+{{count}} XP",
     "reward_xp_estimate": "up to +{{count}} XP",
     "seconds_per_rep": "tempo {{count}}s/rep",
+    "ghost_last": "Last: {{value}}",
+    "swap_exercise": "Replace this movement",
+    "swap_reason_easier": "An easier rung",
+    "swap_reason_harder": "A harder rung",
+    "swap_reason_pattern": "Same movement",
+    "swap_reason_family": "Same family",
     "level": "Level",
     "level_easy": "Easy",
     "level_effect_easy": "Targets −25% · XP ×0.9",
@@ -420,7 +426,9 @@
     "warmup_next_accessibility": "Next movement",
     "countdown_subtitle": "Time to move.",
     "reserve_hint": "Stop with 1-2 reps left in the tank — not at failure.",
-    "crit_hint": "Every rep past the target is a chance to strike critical — {{percent}}% right now."
+    "crit_hint": "Every rep past the target is a chance to strike critical — {{percent}}% right now.",
+    "ghost_last": "Last time: {{value}}",
+    "ghost_last_best": "Last time {{last}} · best {{best}}"
   },
   "muscles": {
     "arms": "Arms",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -517,6 +517,12 @@
     "reward_xp_estimate": "jusqu'à +{{count}} XP",
     "rounds": "{{count}} manches",
     "seconds_per_rep": "tempo {{count}} s/rép",
+    "ghost_last": "Dernier : {{value}}",
+    "swap_exercise": "Remplacer ce mouvement",
+    "swap_reason_easier": "Un échelon plus facile",
+    "swap_reason_harder": "Un échelon plus difficile",
+    "swap_reason_pattern": "Même mouvement",
+    "swap_reason_family": "Même famille",
     "see_all": "Voir tout",
     "start_button": "Commencer la quête",
     "start_error": "Impossible de lancer la quête",
@@ -616,7 +622,9 @@
     "warmup_next_accessibility": "Mouvement suivant",
     "countdown_subtitle": "C'est l'heure de bouger.",
     "reserve_hint": "Garde 1 à 2 répétitions en réserve — ne va pas à l'échec.",
-    "crit_hint": "Chaque répétition au-delà de l'objectif est une chance de coup critique — {{percent}} % pour l'instant."
+    "crit_hint": "Chaque répétition au-delà de l'objectif est une chance de coup critique — {{percent}} % pour l'instant.",
+    "ghost_last": "La dernière fois : {{value}}",
+    "ghost_last_best": "La dernière fois {{last}} · record {{best}}"
   },
   "settings": {
     "avatar": "AVATAR",


### PR DESCRIPTION
Two features that meet on the quest screen. They ship together because the diff on
`app/(tabs)/quests/[id].tsx` interleaves — splitting them would leave a first commit that
does not compile.

## The ghost — see what you have to beat

`completed_exercises` has recorded every set since it existed, and nothing read it back before
or during a session: [`generateTarget()`](db/targets.ts) consulted the journal only for holds.
A hero who did 25 push-ups last time was handed 12 again, with nothing on screen to say so.

**The prescription does not change.** The past shows up as a line under the rep counter and a
tag on the quest screen, and that is all it does. Raising targets from history would silently
recalibrate the variation ladder, which awards a rung after three sessions on target
(`PROGRESSION_SESSIONS_REQUIRED`).

It rides on `QuestExercise` rather than in the session store, which is what makes it free:
`quest` is already inside `SavedSessionState`, so a session recovered after a crash keeps its
ghosts with no second field to keep in sync, and the quest screen gets the same numbers from
the same read.

Three near-duplicate journal readers become one. `getExerciseMax` was `@legacy` with no
callers and a comment naming a caller that does not exist — `app/exercises/[id].tsx` computes
no max at all. Reps and seconds never pool: the unit rides in the key, or a 60 s hold reports
itself as a rep record. "Last time" is the best set of the last session — the rule
`checkForNewRecords` already applies — so what to beat and what the app celebrates are the
same number.

## The swap — adapt a session instead of abandoning it

`QuestConfig` persisted rounds, rest and per-exercise targets but not *which movement*
(roadmap §4.16). A bar movement with no bar, or a wrist that hurts today, ended the session.

`applyQuestConfig` takes the catalogue as a **required** third argument. Made optional,
`loadConfiguredQuest` would have kept compiling while ignoring every swap, and Home would
start push-ups while the quest screen started dips — the divergence AGENTS.md's known-debt
entry warns about. Required, it is a compile error at all three call sites.

A swap clears `images` and `ghost` too: both belong to the movement that used to be in the
slot. Kept, the card illustrates a squat above the word "Dip". The target override is dropped
in the writer, so `applyQuestConfig` stays a pure projection.

### Why the ladder walk is transitive

This is the part that decides whether the feature works at all:

```
depth  movement          pattern          equipment
0      Pull-ups          pull_vertical    pullup_bar
1      Chin-Up           pull_vertical    pullup_bar   ← a one-rung step stops here
...
5      Inverted Row      pull_horizontal  pullup_bar   ← the ladder crosses patterns
6      Table Row         pull_horizontal  none         ← first equipment-free way out
```

All six seeded `pull_vertical` movements need a bar, so "same pattern" hands a bar-less hero
an **empty sheet** on the exact slot that motivates the feature. A new content invariant fails
if any movement in the catalogue loses its equipment-free route out.

Equipment the hero does not own sinks inside its tier rather than disappearing — a kitchen
table is not fitness gear, and only they know what is in the room.

`ExercisePickerSheet` becomes controlled and loses its built-in trigger, which moves to the
editor where its label belongs. The caller orders the list, so one sheet serves both the
editor and substitution with no mode flag.

## Verified

`647 tests · tsc · biome · knip` all clean, and driven on a Fairphone 6 dev build:

- ghost tags read off real history (`Dernier : 14 reps`), and `La dernière fois : 10 reps`
  under the counter mid-session
- nothing at all on a movement never trained — not a `0`
- a swap survives to the running session, with its own art and a target restarted from the
  slot's own window
- the picker's captions name why each candidate is offered

Running it caught the one bug neither `tsc` nor the suite could see: the caption returned a
raw string, and `ExerciseRow` drops `caption` straight into a `YStack` — "Text strings must be
rendered within a `<Text>` component" at runtime, with `ReactNode` happily accepting a string.

## Known limit

Marked `ponytail:` in `db/quests.ts`: `getEligibleQuestIds` filters on the template, so
swapping the bar movement out of a quest does not make Home offer that quest again. The
motivating case is served inside the quest, not in the suggestion.

## Not in scope

Seeding the missing equipment-free pulls. Worth knowing while reviewing: the two that exist
(`Table Row`, `Towel Door Row`) appear in **one quest out of 34**, and without a bar the whole
catalogue offers 6 pull sets against 53 push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
