### PR TITLE
fix(xp): l'XP mesure l'effort, plus l'horloge

### DIFF
--- a/__tests__/adventure-details-cta.test.tsx
+++ b/__tests__/adventure-details-cta.test.tsx
@@ -79,6 +79,7 @@ jest.mock("@/db", () => ({
   startAdventureRun: jest.fn(),
   suggestDifficultyFromSessions: jest.fn().mockReturnValue("medium"),
   estimateQuestTemplateSeconds: jest.fn().mockReturnValue(300),
+  estimateQuestTemplateXp: jest.fn().mockReturnValue(60),
   adventureWeeks: jest.fn().mockReturnValue(1),
 }));
 

--- a/__tests__/exercise-editor.test.tsx
+++ b/__tests__/exercise-editor.test.tsx
@@ -30,7 +30,7 @@ jest.mock("@/db/exercises", () => ({
   updateUserExercise: (...args: unknown[]) => mockUpdate(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   isUserExercise: (ex: { creator: string }) => ex.creator !== "Admin",
-  SECONDS_PER_REP_RANGE: { min: 1, max: 30 },
+  SECONDS_PER_REP_RANGE: { min: 1, max: 10 },
   DEFAULT_USER_EXERCISE_DRAFT: {
     muscles: [],
     style: "strength",

--- a/__tests__/exercise-editor.test.tsx
+++ b/__tests__/exercise-editor.test.tsx
@@ -30,6 +30,7 @@ jest.mock("@/db/exercises", () => ({
   updateUserExercise: (...args: unknown[]) => mockUpdate(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   isUserExercise: (ex: { creator: string }) => ex.creator !== "Admin",
+  SECONDS_PER_REP_RANGE: { min: 1, max: 30 },
   DEFAULT_USER_EXERCISE_DRAFT: {
     muscles: [],
     style: "strength",

--- a/__tests__/migration-xp-clamp.test.ts
+++ b/__tests__/migration-xp-clamp.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createTestDb } from "./helpers/testDb";
+
+/**
+ * `0037_xp_measures_effort.sql` — the one place the XP change reaches backwards.
+ *
+ * The formula rewrite left every journalled `xpEarned` alone on purpose: nobody should be
+ * demoted by an update. But `most_xp` is a *per-session* record read live off `MAX(xpEarned)`
+ * (`db/personalRecords.ts`), so the session that exploited the rest bug would have stood as an
+ * unbeatable "Most XP" forever — in the app of the person who reported the bug. The migration
+ * clamps only the sessions whose XP has no relation to the work they journalled.
+ *
+ * The bar is deliberately generous: three times the session's rep-equivalents. An honest session
+ * under the old formula could reach ~2.5× that (a slow movement plus the daily ×1.5); a session
+ * spent waiting has no bound at all.
+ */
+describe("0037: retroactive XP clamp", () => {
+  const t = createTestDb();
+  afterAll(() => t.close());
+
+  /** The migration has already run on this database (the harness replays the journal). */
+  const migration = fs.readFileSync(
+    path.join(process.cwd(), "drizzle", "0037_xp_measures_effort.sql"),
+    "utf8",
+  );
+
+  function seedSession(id: number, xpEarned: number, sets: [string, number][]): void {
+    t.sqlite
+      .prepare(
+        "INSERT INTO completed_sessions (id, userLevel, xpEarned, notes, performedAt) VALUES (?, 'medium', ?, '', ?)",
+      )
+      .run(id, xpEarned, Date.now());
+
+    const insert = t.sqlite.prepare(
+      "INSERT INTO completed_exercises (sessionId, exerciseId, roundIndex, sortOrder, resultType, resultValue, notes, performedAt) VALUES (?, 1, 0, ?, ?, ?, '', ?)",
+    );
+    sets.forEach(([type, value], i) => {
+      insert.run(id, i, type, value, Date.now());
+    });
+  }
+
+  const xpOf = (id: number): number =>
+    (
+      t.sqlite.prepare("SELECT xpEarned FROM completed_sessions WHERE id = ?").get(id) as {
+        xpEarned: number;
+      }
+    ).xpEarned;
+
+  test("clamps the exploit and leaves honest sessions untouched", () => {
+    // The bug as reported: five hours of rest, one token set, 3600 XP.
+    seedSession(1, 3600, [["reps", 12]]);
+    // 15 × 12 reps — 180 XP under the new formula, 360 under the old.
+    seedSession(
+      2,
+      360,
+      Array.from<never, [string, number]>({ length: 15 }, () => ["reps", 12]),
+    );
+    // A slow mobility session that also caught the daily ×1.5 — the closest an honest hero gets.
+    seedSession(
+      3,
+      405,
+      Array.from<never, [string, number]>({ length: 12 }, () => ["time", 45]),
+    );
+
+    t.sqlite.exec(migration);
+
+    // 3 × 12 rep-equivalents. The work is what it is.
+    expect(xpOf(1)).toBe(36);
+    expect(xpOf(2)).toBe(360);
+    expect(xpOf(3)).toBe(405);
+  });
+
+  test("is idempotent — a second run moves nothing", () => {
+    const before = [1, 2, 3].map(xpOf);
+    t.sqlite.exec(migration);
+    expect([1, 2, 3].map(xpOf)).toEqual(before);
+  });
+
+  test("never drops a session below the floor a completed session is worth", () => {
+    seedSession(4, 2000, [["reps", 1]]);
+    t.sqlite.exec(migration);
+
+    expect(xpOf(4)).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/__tests__/preview.test.ts
+++ b/__tests__/preview.test.ts
@@ -1,4 +1,4 @@
-import { estimateQuestTemplateSeconds } from "@/db/preview";
+import { estimateQuestTemplateSeconds, estimateQuestTemplateXp } from "@/db/preview";
 
 describe("db/preview", () => {
   test("estimateQuestTemplateSeconds accounts for rounds + rest + generated targets", () => {
@@ -16,7 +16,7 @@ describe("db/preview", () => {
     };
 
     const exercisesById = {
-      1: { secondsPerRep: 2 },
+      1: { secondsPerRep: 2, difficulty: "medium" as const },
     };
 
     const medium = estimateQuestTemplateSeconds({
@@ -37,5 +37,48 @@ describe("db/preview", () => {
 
     // hard multiplier 1.25 => 10 -> 13, reps: 13*2=26 per round; rounds=2 => 52; +30 rest
     expect(hard).toBe(82);
+  });
+
+  /**
+   * The bug as it was reported: "a 300 minute break gives me a lot of XP".
+   *
+   * The rest slider is what made the exploit findable — the gallery's "up to +N XP" chip moved
+   * with it, so the screen advertised the cheat. XP is paid for effort now, and rest is not
+   * effort, so the two templates below differ only in a column the XP estimate must not read.
+   */
+  test("the XP estimate does not move when the rest slider does", () => {
+    const exercisesById = { 1: { secondsPerRep: 3, difficulty: "medium" as const } };
+    const base = {
+      rounds: 10,
+      exercises: [
+        { exerciseId: 1, images: [], baseTarget: { type: "reps" as const, min: 12, max: 12 } },
+      ],
+    };
+
+    const brisk = estimateQuestTemplateXp({
+      template: { ...base, restSeconds: 30, roundRestSeconds: null },
+      exercisesById,
+      userLevel: "medium",
+    });
+    const glacial = estimateQuestTemplateXp({
+      template: { ...base, restSeconds: 300, roundRestSeconds: 300 },
+      exercisesById,
+      userLevel: "medium",
+    });
+
+    expect(glacial).toBe(brisk);
+
+    // ...while the duration estimate, whose job *is* the clock, still does.
+    const briskSeconds = estimateQuestTemplateSeconds({
+      template: { ...base, restSeconds: 30, roundRestSeconds: null },
+      exercisesById,
+      userLevel: "medium",
+    });
+    const glacialSeconds = estimateQuestTemplateSeconds({
+      template: { ...base, restSeconds: 300, roundRestSeconds: 300 },
+      exercisesById,
+      userLevel: "medium",
+    });
+    expect(glacialSeconds).toBeGreaterThan(briskSeconds);
   });
 });

--- a/__tests__/quest-details-navigation.test.tsx
+++ b/__tests__/quest-details-navigation.test.tsx
@@ -72,6 +72,7 @@ jest.mock("@/db", () => ({
   getQuestConfig: jest.fn().mockResolvedValue(null),
   applyQuestConfig: (quest: unknown) => quest,
   estimateQuestSeconds: jest.fn().mockReturnValue(300),
+  estimateQuestXp: jest.fn().mockReturnValue(60),
   formatDurationEstimate: jest.fn().mockReturnValue("5 min"),
   indexExercises: jest.fn().mockReturnValue(new Map()),
   isUserQuest: jest.fn().mockReturnValue(false),

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -55,6 +55,9 @@ jest.mock("@/src/widget", () => ({
 }));
 jest.mock("@/db/xp", () => ({
   computeSessionXp: jest.fn().mockReturnValue(100),
+  // Real value, not a stand-in: `saveSession` clamps with it, and a mock that omits it turns the
+  // session's XP into NaN with no error anywhere.
+  MAX_SESSION_XP: 2000,
 }));
 jest.mock("@/db/preferences", () => ({
   preferences: {

--- a/__tests__/xp.test.ts
+++ b/__tests__/xp.test.ts
@@ -135,7 +135,7 @@ describe("db/xp", () => {
 
     expect(
       computeSessionXp({ sets: sets("easy"), effortCeilingSeconds: ceiling, userLevel: "medium" }),
-    ).toBe(102);
+    ).toBe(96);
     expect(
       computeSessionXp({
         sets: sets("medium"),
@@ -145,7 +145,25 @@ describe("db/xp", () => {
     ).toBe(120);
     expect(
       computeSessionXp({ sets: sets("hard"), effortCeilingSeconds: ceiling, userLevel: "medium" }),
-    ).toBe(150);
+    ).toBe(300);
+  });
+
+  /**
+   * At `DIFFICULTY_WEIGHT.hard = 2.5` the two quantities diverge badly, so the order matters: the
+   * ceiling bounds *physical* seconds, the weight prices them. Weighting first would clip every
+   * honest session of hard movements against its own clock.
+   */
+  test("the ceiling bounds real seconds, not what they were worth", () => {
+    // 10 × 12 reps × 3s = 360 real seconds of hard work, inside a ten-minute window.
+    const sets = Array.from({ length: 10 }, () => reps(12, 12, movement("hard")));
+
+    expect(computeSessionXp({ sets, effortCeilingSeconds: 10 * 60, userLevel: "medium" })).toBe(
+      300,
+    );
+
+    // Halve the window below what the work needed and the credit halves with it — it neither
+    // collapses to the clock nor survives untouched.
+    expect(computeSessionXp({ sets, effortCeilingSeconds: 150, userLevel: "medium" })).toBe(150);
   });
 
   test("the hero's chosen level still scales the reward", () => {

--- a/__tests__/xp.test.ts
+++ b/__tests__/xp.test.ts
@@ -1,36 +1,223 @@
-import { computeSessionXp } from "@/db/xp";
+import type { DifficultyCode } from "@/db/schema";
+import { computeSessionXp, estimateQuestXp, MAX_SESSION_XP, type XpSet } from "@/db/xp";
+
+const MEDIUM: XpSet["exercise"] = { secondsPerRep: 3, difficulty: "medium" };
+
+const movement = (difficulty: DifficultyCode, secondsPerRep = 3): XpSet["exercise"] => ({
+  secondsPerRep,
+  difficulty,
+});
+
+/** One rep-based set: what was asked, what was done. Default tempo, so 1 rep ≈ 1 XP. */
+function reps(target: number, result = target, exercise = MEDIUM): XpSet {
+  return {
+    exercise,
+    target: { type: "reps", value: target },
+    result: { type: "reps", value: result },
+  };
+}
+
+function hold(target: number, result = target, exercise = MEDIUM): XpSet {
+  return {
+    exercise,
+    target: { type: "time", value: target },
+    result: { type: "time", value: result },
+  };
+}
+
+/** A plausible session: 15 sets of 12 reps, 540 seconds of effort. */
+const HONEST_SETS = Array.from({ length: 15 }, () => reps(12));
+const HONEST_ELAPSED = 30 * 60;
 
 describe("db/xp", () => {
-  test("gives a small floor even for very short sessions", () => {
-    expect(computeSessionXp({ durationSeconds: 0, userLevel: "medium" })).toBeGreaterThanOrEqual(
-      10,
-    );
-    expect(computeSessionXp({ durationSeconds: 3, userLevel: "medium" })).toBeGreaterThanOrEqual(
-      10,
-    );
+  test("no session is wasted — there is always a floor", () => {
+    expect(computeSessionXp({ sets: [], effortCeilingSeconds: 0, userLevel: "medium" })).toBe(10);
+    expect(
+      computeSessionXp({ sets: [reps(1)], effortCeilingSeconds: 5, userLevel: "medium" }),
+    ).toBe(10);
   });
 
-  test("scales with duration", () => {
-    const short = computeSessionXp({
-      durationSeconds: 60,
-      userLevel: "medium",
-    });
-    const long = computeSessionXp({
-      durationSeconds: 600,
-      userLevel: "medium",
-    });
-    expect(long).toBeGreaterThan(short);
+  test("pays for the effort a session contained", () => {
+    // 15 sets × 12 reps × 3s = 540s of effort, at one XP per three seconds.
+    expect(
+      computeSessionXp({
+        sets: HONEST_SETS,
+        effortCeilingSeconds: HONEST_ELAPSED,
+        userLevel: "medium",
+      }),
+    ).toBe(180);
   });
 
-  test("difficulty multiplier affects xp", () => {
-    const base = computeSessionXp({
-      durationSeconds: 300,
+  /**
+   * The bug as reported: "a 300 minute break gives me a lot of XP".
+   *
+   * Elapsed time is a ceiling on how much effort could have been real, never a source of XP. A
+   * session left open for three hours pays exactly what the same work paid in twenty minutes —
+   * under the old `durationSeconds / 5` it paid 2160.
+   */
+  test("waiting earns nothing: the same work pays the same after three hours", () => {
+    const brisk = computeSessionXp({
+      sets: HONEST_SETS,
+      effortCeilingSeconds: 20 * 60,
       userLevel: "medium",
     });
-    const easy = computeSessionXp({ durationSeconds: 300, userLevel: "easy" });
-    const hard = computeSessionXp({ durationSeconds: 300, userLevel: "hard" });
+    const abandoned = computeSessionXp({
+      sets: HONEST_SETS,
+      effortCeilingSeconds: 3 * 60 * 60,
+      userLevel: "medium",
+    });
 
-    expect(easy).toBeLessThan(base);
-    expect(hard).toBeGreaterThan(base);
+    expect(abandoned).toBe(brisk);
+    expect(abandoned).toBe(180);
+  });
+
+  /**
+   * The regression the first draft of this fix would have shipped.
+   *
+   * Paying for declared work and nothing else made tapping fifty sets through in twenty seconds
+   * worth full price — closing "wait five hours" by opening something nine hundred times cheaper.
+   * Effort cannot exceed the window it happened in.
+   */
+  test("a session tapped through in twenty seconds is worth twenty seconds", () => {
+    expect(
+      computeSessionXp({ sets: HONEST_SETS, effortCeilingSeconds: 20, userLevel: "medium" }),
+    ).toBe(10);
+  });
+
+  /**
+   * A hold's result *is* a clock — `ActiveExerciseView` records elapsed seconds and overtime is
+   * unbounded — so a phone left face-up on a 30s plank declares two hours without anyone lying.
+   * Reps are typed by a hero who is present; holds are not, so they get no decaying tail.
+   */
+  test("a hold left running is credited at its target, not at its clock", () => {
+    const honest = computeSessionXp({
+      sets: [hold(30)],
+      effortCeilingSeconds: 60,
+      userLevel: "medium",
+    });
+    const abandoned = computeSessionXp({
+      sets: [hold(30, 2 * 60 * 60)],
+      effortCeilingSeconds: 2 * 60 * 60,
+      userLevel: "medium",
+    });
+
+    expect(honest).toBe(10);
+    expect(abandoned).toBe(13); // the +25% allowance, and not one second more
+  });
+
+  test("beating a target pays, then resists — it never stops paying", () => {
+    const met = computeSessionXp({
+      sets: [reps(12)],
+      effortCeilingSeconds: 300,
+      userLevel: "medium",
+    });
+    const beaten = computeSessionXp({
+      sets: [reps(12, 15)],
+      effortCeilingSeconds: 300,
+      userLevel: "medium",
+    });
+    const doubled = computeSessionXp({
+      sets: [reps(12, 24)],
+      effortCeilingSeconds: 300,
+      userLevel: "medium",
+    });
+
+    expect(met).toBe(12);
+    expect(beaten).toBe(15); // +25%, paid in full
+    expect(doubled).toBe(17); // twice the reps, well short of twice the XP — but still more
+    expect(doubled).toBeGreaterThan(beaten);
+  });
+
+  test("a harder movement is worth more per second than an easier one", () => {
+    const ceiling = 60 * 60;
+    const sets = (difficulty: "easy" | "medium" | "hard") =>
+      Array.from({ length: 10 }, () => reps(12, 12, movement(difficulty)));
+
+    expect(
+      computeSessionXp({ sets: sets("easy"), effortCeilingSeconds: ceiling, userLevel: "medium" }),
+    ).toBe(102);
+    expect(
+      computeSessionXp({
+        sets: sets("medium"),
+        effortCeilingSeconds: ceiling,
+        userLevel: "medium",
+      }),
+    ).toBe(120);
+    expect(
+      computeSessionXp({ sets: sets("hard"), effortCeilingSeconds: ceiling, userLevel: "medium" }),
+    ).toBe(150);
+  });
+
+  test("the hero's chosen level still scales the reward", () => {
+    const sets = Array.from({ length: 10 }, () => reps(12));
+    const at = (userLevel: "easy" | "medium" | "hard") =>
+      computeSessionXp({ sets, effortCeilingSeconds: 60 * 60, userLevel });
+
+    expect(at("easy")).toBe(108);
+    expect(at("medium")).toBe(120);
+    expect(at("hard")).toBe(144);
+  });
+
+  /**
+   * The other regression the first draft would have shipped: a per-quest cap of `nominal × 1.25`,
+   * where every factor of `nominal` is typed in by the hero. Ten rounds × five exercises × 999
+   * reps has a "nominal" of fifty thousand, and that draft would have paid 62 437 XP for it —
+   * twenty times the exploit it was written to close. `MAX_SESSION_XP` is the only bound no
+   * input can raise.
+   */
+  test("a hero-authored monster quest is bounded by the one cap no input can raise", () => {
+    const monster = {
+      rounds: 10,
+      exercises: Array.from({ length: 5 }, () => ({
+        exercise: MEDIUM,
+        target: { type: "reps" as const, value: 999 },
+      })),
+    };
+
+    expect(estimateQuestXp(monster, "medium")).toBe(MAX_SESSION_XP);
+
+    // And performed rather than previewed, over a four-hour session.
+    const performed = Array.from({ length: 50 }, () => reps(999));
+    expect(
+      computeSessionXp({
+        sets: performed,
+        effortCeilingSeconds: 4 * 60 * 60,
+        userLevel: "hard",
+      }),
+    ).toBe(MAX_SESSION_XP);
+  });
+
+  /**
+   * `docs/gameplay/progression.md` designs the 10-15 minute mobility session as a retention
+   * mechanic: low-fatigue by design, done on a day the hero should not train hard, and it still
+   * lights the flame. A formula that pays for effort could have quietly killed it. Holds convert
+   * second for second, so it gains instead — 204 against the 180 the old clock paid.
+   */
+  test("a mobility session does not lose by the change", () => {
+    const sets = Array.from({ length: 16 }, () => hold(45, 45, movement("easy")));
+
+    expect(
+      computeSessionXp({ sets, effortCeilingSeconds: 15 * 60, userLevel: "medium" }),
+    ).toBeGreaterThan(180);
+  });
+
+  test("estimateQuestXp advertises the allowance, and reads no rest column", () => {
+    const quest = {
+      rounds: 3,
+      exercises: Array.from({ length: 4 }, () => ({
+        exercise: MEDIUM,
+        target: { type: "reps" as const, value: 12 },
+      })),
+    };
+
+    // 3 × 4 × 12 reps = 144 XP met exactly, 180 with the full +25% the chip advertises.
+    expect(estimateQuestXp(quest, "medium")).toBe(180);
+    expect(
+      computeSessionXp({
+        sets: Array.from({ length: 12 }, () => reps(12)),
+        effortCeilingSeconds: 60 * 60,
+        userLevel: "medium",
+      }),
+    ).toBe(144);
   });
 });

--- a/app/(tabs)/adventures/[id].tsx
+++ b/app/(tabs)/adventures/[id].tsx
@@ -29,6 +29,7 @@ import {
   adventureWeeks,
   Difficulty,
   estimateQuestTemplateSeconds,
+  estimateQuestTemplateXp,
   getActiveAdventureRun,
   getAdventureDetails,
   getFinishedRunCountsByAdventure,
@@ -40,7 +41,6 @@ import {
 import { type BossFight, getBossFightByAdventure } from "@/db/bossFights";
 import type { Exercise } from "@/db/exercises";
 import { MUSCLE_LABELS } from "@/db/muscles";
-import { computeSessionXp } from "@/db/xp";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { reportError } from "@/src/reportError";
 import { useSettingsStore } from "@/stores/settings";
@@ -330,13 +330,14 @@ export default function AdventureDetailsScreen() {
   const preview = useMemo(() => {
     if (!activeTemplateStep) return null;
 
-    const durationSeconds = estimateQuestTemplateSeconds({
+    const previewInput = {
       template: activeTemplateStep.quest,
       exercisesById: state.exercisesById,
       userLevel: effectiveDifficulty,
-    });
+    };
 
-    const xp = computeSessionXp({ durationSeconds, userLevel: effectiveDifficulty });
+    const durationSeconds = estimateQuestTemplateSeconds(previewInput);
+    const xp = estimateQuestTemplateXp(previewInput);
 
     return {
       durationSeconds,

--- a/app/(tabs)/adventures/index.tsx
+++ b/app/(tabs)/adventures/index.tsx
@@ -26,6 +26,7 @@ import {
   type Adventure,
   adventureWeeks,
   estimateQuestTemplateSeconds,
+  estimateQuestTemplateXp,
   getAnyActiveAdventureRun,
   getFinishedRunCountsByAdventure,
   listAdventures,
@@ -34,7 +35,6 @@ import {
 import type { Exercise } from "@/db/exercises";
 import { MUSCLE_LABELS } from "@/db/muscles";
 import { getAllQuestConfigs, type QuestConfig, resolveTemplateOverrides } from "@/db/questConfig";
-import { computeSessionXp } from "@/db/xp";
 import { reportError } from "@/src/reportError";
 import { type AppLanguage, useSettingsStore } from "@/stores/settings";
 
@@ -95,12 +95,13 @@ function buildAdventureRow(
   // Same numbers as the quest detail/gallery: the saved level and structure overrides feed
   // the estimate, priced off the cover quest — the one step the poster's XP chip advertises.
   const level = config?.level ?? "medium";
-  const durationSeconds = estimateQuestTemplateSeconds({
+  const previewInput = {
     template: { ...q, ...resolveTemplateOverrides(q, config) },
     exercisesById,
     userLevel: level,
-  });
-  const xp = computeSessionXp({ durationSeconds, userLevel: level });
+  };
+  const durationSeconds = estimateQuestTemplateSeconds(previewInput);
+  const xp = estimateQuestTemplateXp(previewInput);
   const weeks = adventureWeeks(a.stepsCount);
 
   return {

--- a/app/(tabs)/quests/[id].tsx
+++ b/app/(tabs)/quests/[id].tsx
@@ -24,6 +24,7 @@ import {
   applyQuestConfig,
   Difficulty,
   estimateQuestSeconds,
+  estimateQuestXp,
   formatDurationEstimate,
   getQuestById,
   getQuestConfig,
@@ -41,7 +42,6 @@ import { getCached } from "@/db/queryCache";
 import type { Quest } from "@/db/quests";
 import type { DifficultyCode, EquipmentCode } from "@/db/schema";
 import { formatTarget } from "@/db/targets";
-import { computeSessionXp } from "@/db/xp";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useSessionStore } from "@/stores/session";
@@ -356,10 +356,7 @@ export default function QuestDetails() {
       questTokens: getQuestColorTokensFromQuest(quest),
       estimatedSeconds,
       estimate: formatDurationEstimate(estimatedSeconds),
-      xpReward: computeSessionXp({
-        durationSeconds: estimatedSeconds,
-        userLevel: level as unknown as DifficultyCode,
-      }),
+      xpReward: estimateQuestXp(quest, level as unknown as DifficultyCode),
     };
   }, [state.quest, config, language, level, catalogue]);
 

--- a/app/(tabs)/quests/index.tsx
+++ b/app/(tabs)/quests/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/constants/questFilters";
 import {
   estimateQuestTemplateSeconds,
+  estimateQuestTemplateXp,
   formatDurationEstimate,
   isUserQuest,
   listExercises,
@@ -42,7 +43,6 @@ import { MUSCLE_LABELS } from "@/db/muscles";
 import { getAllQuestConfigs, type QuestConfig, resolveTemplateOverrides } from "@/db/questConfig";
 import type { QuestTemplate } from "@/db/quests";
 import type { EquipmentCode, MuscleCode, QuestArchetype } from "@/db/schema";
-import { computeSessionXp } from "@/db/xp";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { type AppLanguage, useSettingsStore } from "@/stores/settings";
@@ -121,12 +121,13 @@ function buildQuestMeta(
   // estimateQuestSeconds sees them, so a target-overridden quest can still drift by
   // a few seconds; fold them in if anyone notices.
   const level = config?.level ?? "medium";
-  const durationSeconds = estimateQuestTemplateSeconds({
+  const previewInput = {
     template: { ...q, ...resolveTemplateOverrides(q, config) },
     exercisesById,
     userLevel: level,
-  });
-  const xp = computeSessionXp({ durationSeconds, userLevel: level });
+  };
+  const durationSeconds = estimateQuestTemplateSeconds(previewInput);
+  const xp = estimateQuestTemplateXp(previewInput);
   const estimate = formatDurationEstimate(durationSeconds);
   const muscleList = [...muscles];
   // Ranked, not the full set above: a five-exercise quest brushes five muscle groups, and the

--- a/app/exercises/new.tsx
+++ b/app/exercises/new.tsx
@@ -19,6 +19,7 @@ import {
   DEFAULT_USER_EXERCISE_DRAFT,
   getExerciseById,
   isUserExercise,
+  SECONDS_PER_REP_RANGE,
   type UserExerciseDraft,
   updateUserExercise,
 } from "@/db/exercises";
@@ -39,9 +40,6 @@ type Details = Omit<UserExerciseDraft, "name" | "description">;
 
 /** The movement art already in the APK. */
 const EXERCISE_CHOICES = Object.keys(EXERCISE_THUMB_ASSETS);
-
-const SECONDS_PER_REP_MIN = 1;
-const SECONDS_PER_REP_MAX = 30;
 
 /**
  * Where a hero writes a movement of their own.
@@ -320,8 +318,8 @@ export default function ExerciseEditor() {
                 label={t("exercise_editor.seconds_per_rep")}
                 hint={t("exercise_editor.seconds_per_rep_hint")}
                 value={details.secondsPerRep}
-                min={SECONDS_PER_REP_MIN}
-                max={SECONDS_PER_REP_MAX}
+                min={SECONDS_PER_REP_RANGE.min}
+                max={SECONDS_PER_REP_RANGE.max}
                 onChange={(secondsPerRep) => setDetails((d) => ({ ...d, secondsPerRep }))}
               />
             </YStack>

--- a/components/session/VictoryView.tsx
+++ b/components/session/VictoryView.tsx
@@ -393,6 +393,17 @@ export function VictoryView() {
                 {t("common.daily_xp_bonus")}
               </Text>
             )}
+            {!!result?.overshootXp && (
+              <Text
+                fontWeight="700"
+                fontSize={11}
+                color="$success"
+                text="center"
+                fontFamily="$body"
+              >
+                {t("session.xp_overshoot", { count: result.overshootXp })}
+              </Text>
+            )}
           </Card>
         </XStack>
 

--- a/db/bossFights.ts
+++ b/db/bossFights.ts
@@ -100,8 +100,13 @@ export const SHINY_CHANCE = 0.05;
  * decides. This: empty it with your own damage — meet targets, push past them for crits, land the
  * weakness — and the kill is a Triumph, worth this bonus on the session that dealt the killing
  * hit. Fall short and the final blow still fells it, at no cost but the bonus. Reward for
- * pushing, never punishment for training under target. Twice the oath's bonus, because a boss is
- * not a mini-boss.
+ * pushing, never punishment for training under target.
+ *
+ * ponytail: this comment claimed "twice the oath's bonus" for months while `OATH_XP_BONUS` was
+ *           250 — it is 0.4×, not 2×. Only the claim is corrected here; the number is a balance
+ *           call, and it wants a decision rather than a quiet edit. Against the effort-based
+ *           economy (`db/xp.ts`), where an honest session pays ~300, felling a campaign boss
+ *           currently pays a third of one. Raise it if that reads wrong on a device.
  */
 export const TRIUMPH_XP_BONUS = 100;
 

--- a/db/exercises.ts
+++ b/db/exercises.ts
@@ -599,11 +599,15 @@ export type UserExerciseDraft = {
 /**
  * The tempo a hero may claim for their own movement.
  *
- * Mirrors `app/exercises/new.tsx`'s stepper, which was the only thing enforcing it — the writers
- * below took `draft.secondsPerRep` raw. It is not cosmetic: XP counts seconds of effort at this
- * tempo, so an unbounded value is a multiplier on the reward for every rep of that movement.
+ * The stepper in `app/exercises/new.tsx` was the only thing enforcing this — the writers below
+ * took `draft.secondsPerRep` raw — and it allowed up to 30. That is not cosmetic: XP counts
+ * seconds of effort at this tempo, so 30 was a ×10 multiplier on every rep of a hero's own
+ * movement, against a seeded catalogue that spans 1 to 5.
+ *
+ * 10 is twice the slowest movement anyone has authored. Past that it is not a repetition at all,
+ * it is a hold, and holds have their own target type — which is measured rather than declared.
  */
-export const SECONDS_PER_REP_RANGE = { min: 1, max: 30 };
+export const SECONDS_PER_REP_RANGE = { min: 1, max: 10 };
 
 function clampSecondsPerRep(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_SECONDS_PER_REP;

--- a/db/exercises.ts
+++ b/db/exercises.ts
@@ -596,13 +596,32 @@ export type UserExerciseDraft = {
  * and `getMuscleBalance` reports how much it is not counting rather than quietly shrinking a
  * total.
  */
+/**
+ * The tempo a hero may claim for their own movement.
+ *
+ * Mirrors `app/exercises/new.tsx`'s stepper, which was the only thing enforcing it — the writers
+ * below took `draft.secondsPerRep` raw. It is not cosmetic: XP counts seconds of effort at this
+ * tempo, so an unbounded value is a multiplier on the reward for every rep of that movement.
+ */
+export const SECONDS_PER_REP_RANGE = { min: 1, max: 30 };
+
+function clampSecondsPerRep(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_SECONDS_PER_REP;
+  return Math.min(
+    SECONDS_PER_REP_RANGE.max,
+    Math.max(SECONDS_PER_REP_RANGE.min, Math.round(value)),
+  );
+}
+
+const DEFAULT_SECONDS_PER_REP = 3;
+
 export const DEFAULT_USER_EXERCISE_DRAFT: Omit<UserExerciseDraft, "name" | "description"> = {
   muscles: [],
   style: "strength",
   difficulty: "medium",
   equipment: "none",
   pattern: null,
-  secondsPerRep: 3,
+  secondsPerRep: DEFAULT_SECONDS_PER_REP,
   imagePath: "assets/placeholder.webp",
 };
 
@@ -672,7 +691,7 @@ export async function createUserExercise(draft: UserExerciseDraft): Promise<numb
       equipment: draft.equipment,
       style: draft.style,
       pattern: draft.pattern,
-      secondsPerRep: draft.secondsPerRep,
+      secondsPerRep: clampSecondsPerRep(draft.secondsPerRep),
       createdAt: new Date(),
       updatedAt: new Date(),
     })
@@ -701,7 +720,7 @@ export async function updateUserExercise(id: number, draft: UserExerciseDraft): 
       equipment: draft.equipment,
       style: draft.style,
       pattern: draft.pattern,
-      secondsPerRep: draft.secondsPerRep,
+      secondsPerRep: clampSecondsPerRep(draft.secondsPerRep),
       updatedAt: new Date(),
     })
     .where(eq(exercises.id, id));

--- a/db/index.ts
+++ b/db/index.ts
@@ -43,7 +43,7 @@ export {
   unretireUserExercise,
 } from "./exercises";
 export { preferences, type TrainingLevel } from "./preferences";
-export { estimateQuestTemplateSeconds } from "./preview";
+export { estimateQuestTemplateSeconds, estimateQuestTemplateXp } from "./preview";
 export type { QuestConfig } from "./questConfig";
 export {
   applyQuestConfig,
@@ -75,3 +75,6 @@ export {
   getTotalXp,
   getXpForLevel,
 } from "./userLevel";
+// `db/xp.ts` is the only place the XP arithmetic and its constants live. Only the screens' entry
+// point is re-exported here; `saveSession` and the tests import the module itself.
+export { estimateQuestXp } from "./xp";

--- a/db/preview.ts
+++ b/db/preview.ts
@@ -3,12 +3,21 @@ import type { Exercise } from "./exercises";
 import type { QuestTemplate } from "./quests";
 import type { DifficultyCode } from "./schema";
 import { Difficulty, generateTarget } from "./targets";
+import { estimateQuestXp } from "./xp";
 
-export function estimateQuestTemplateSeconds(input: {
+type PreviewInput = {
   template: Pick<QuestTemplate, "rounds" | "restSeconds" | "roundRestSeconds" | "exercises">;
-  exercisesById: Record<number, Pick<Exercise, "secondsPerRep">>;
+  exercisesById: Record<number, Pick<Exercise, "secondsPerRep" | "difficulty">>;
   userLevel: DifficultyCode;
-}): number {
+};
+
+/**
+ * The template's slots with their targets resolved for this hero — what both previews price off.
+ *
+ * Shared so the duration chip and the XP chip can never disagree about which movements a quest
+ * contains or what it asks of them.
+ */
+function resolveTemplateExercises(input: PreviewInput) {
   const userLevelEnum =
     input.userLevel === "easy"
       ? Difficulty.Easy
@@ -16,7 +25,7 @@ export function estimateQuestTemplateSeconds(input: {
         ? Difficulty.Hard
         : Difficulty.Medium;
 
-  const exercises = input.template.exercises
+  return input.template.exercises
     .map((qex) => {
       const ex = input.exercisesById[qex.exerciseId];
       if (!ex) return null;
@@ -35,16 +44,32 @@ export function estimateQuestTemplateSeconds(input: {
       );
 
       return {
-        exercise: { secondsPerRep: ex.secondsPerRep },
+        exercise: { secondsPerRep: ex.secondsPerRep, difficulty: ex.difficulty },
         target,
       };
     })
     .filter((x): x is NonNullable<typeof x> => x != null);
+}
 
+export function estimateQuestTemplateSeconds(input: PreviewInput): number {
   return estimateQuestSeconds({
     rounds: input.template.rounds,
     restSeconds: input.template.restSeconds,
     roundRestSeconds: input.template.roundRestSeconds,
-    exercises,
+    exercises: resolveTemplateExercises(input),
   });
+}
+
+/**
+ * The XP chip on a quest card or an adventure poster.
+ *
+ * Deliberately does not take the rest columns: XP is paid for effort, and a card whose XP moved
+ * with the rest slider is how the rest exploit was discovered — the screen advertised +2940 XP
+ * for a quest that was mostly sitting.
+ */
+export function estimateQuestTemplateXp(input: PreviewInput): number {
+  return estimateQuestXp(
+    { rounds: input.template.rounds, exercises: resolveTemplateExercises(input) },
+    input.userLevel,
+  );
 }

--- a/db/questConfig.ts
+++ b/db/questConfig.ts
@@ -35,8 +35,19 @@ export const TARGET_RANGE = { min: 1, max: 999 };
 
 const configKey = (questId: number) => `quest:${questId}:config`;
 
-function clamp(value: number, range: { min: number; max: number }): number {
+/**
+ * Exported because the ranges above were UI-only for a long time: the steppers refused to go past
+ * them and every writer below `db/` took whatever it was handed. A quest saved by an editor that
+ * skipped its own stepper — or by a future screen that forgets one — reached SQLite unbounded, and
+ * the schema has no CHECK on any of these columns. Writers clamp with this now.
+ */
+export function clampToRange(value: number, range: { min: number; max: number }): number {
+  if (!Number.isFinite(value)) return range.min;
   return Math.min(range.max, Math.max(range.min, Math.round(value)));
+}
+
+function clamp(value: number, range: { min: number; max: number }): number {
+  return clampToRange(value, range);
 }
 
 function isLevel(value: unknown): value is UserLevel {

--- a/db/quests.ts
+++ b/db/quests.ts
@@ -6,6 +6,7 @@ import { isMuscleCode } from "./muscles";
 import { type ExerciseGhost, getExerciseHistory, ghostKey } from "./personalRecords";
 import { preferences, type TrainingLevel } from "./preferences";
 import { clearCached, setCached } from "./queryCache";
+import { clampToRange, REST_RANGE, ROUNDS_RANGE, TARGET_RANGE } from "./questConfig";
 import {
   ADMIN_CREATOR,
   type ContentOwner,
@@ -189,9 +190,10 @@ export async function createQuestTemplate(input: CreateQuestTemplateInput): Prom
       frDescription: input.frDescription,
       author: input.author ?? ADMIN_CREATOR,
       imagePath: input.imagePath ?? null,
-      rounds: input.rounds,
-      restSeconds: input.restSeconds,
-      roundRestSeconds: input.roundRestSeconds,
+      rounds: clampToRange(input.rounds, ROUNDS_RANGE),
+      restSeconds: clampToRange(input.restSeconds, REST_RANGE),
+      roundRestSeconds:
+        input.roundRestSeconds === null ? null : clampToRange(input.roundRestSeconds, REST_RANGE),
       createdAt: new Date(),
       updatedAt: new Date(),
     })
@@ -217,8 +219,8 @@ export async function createQuestTemplate(input: CreateQuestTemplateInput): Prom
         exerciseId: qex.exerciseId,
         sortOrder: i,
         targetType: qex.baseTarget.type,
-        targetMin: qex.baseTarget.min,
-        targetMax: qex.baseTarget.max,
+        targetMin: clampToRange(qex.baseTarget.min, TARGET_RANGE),
+        targetMax: clampToRange(qex.baseTarget.max, TARGET_RANGE),
         imagesJson: JSON.stringify(qex.images ?? []),
       })),
     );
@@ -543,6 +545,15 @@ export async function updateQuestMeta(
     .update(quests)
     .set({
       ...patch,
+      // Spread first, then re-state the bounded columns: `...patch` is a partial, so each one is
+      // only touched when the caller actually sent it.
+      ...(patch.rounds === undefined ? {} : { rounds: clampToRange(patch.rounds, ROUNDS_RANGE) }),
+      ...(patch.restSeconds === undefined
+        ? {}
+        : { restSeconds: clampToRange(patch.restSeconds, REST_RANGE) }),
+      ...(patch.roundRestSeconds === undefined || patch.roundRestSeconds === null
+        ? {}
+        : { roundRestSeconds: clampToRange(patch.roundRestSeconds, REST_RANGE) }),
       updatedAt: new Date(),
     })
     .where(eq(quests.id, id));
@@ -568,8 +579,8 @@ export async function setQuestExercises(
         exerciseId: qex.exerciseId,
         sortOrder: i,
         targetType: qex.baseTarget.type,
-        targetMin: qex.baseTarget.min,
-        targetMax: qex.baseTarget.max,
+        targetMin: clampToRange(qex.baseTarget.min, TARGET_RANGE),
+        targetMax: clampToRange(qex.baseTarget.max, TARGET_RANGE),
         imagesJson: JSON.stringify(qex.images ?? []),
       })),
     );

--- a/db/xp.ts
+++ b/db/xp.ts
@@ -67,14 +67,23 @@ const XP_FLOOR = 10;
  * What a movement is worth per second of effort.
  *
  * Without it the optimal strategy is the easiest exercise in the catalogue: `toRepEquivalent` is
- * flat, so fifty jumping jacks and fifty pull-ups weigh the same. Kept narrow on purpose — a hero
- * can mark their own movement `hard` (`db/exercises.ts`, `createUserExercise`), and a 1.25×
- * self-grant is not worth defending against.
+ * flat, so fifty jumping jacks and fifty pull-ups weigh the same.
+ *
+ * The spread is wide because a narrow one was measured against the seeded catalogue and found to
+ * punish the two archetypes it should reward. `skill` and `strength` quests are 80-87% rest *by
+ * protocol* — ten seconds of front lever, two minutes of recovery — so any volume metric
+ * undervalues them: at 0.85/1.0/1.25 they paid 0.31× and 0.51× of what the old clock paid, while
+ * `mobility` kept 0.97×. A hard rep being worth roughly three easy ones is also just true; one
+ * pull-up is not one jumping jack.
+ *
+ * A hero can mark their own movement `hard` (`createUserExercise`), which is now a 2.5× self-grant
+ * rather than 1.25×. It is bounded by the effort ceiling and `MAX_SESSION_XP` like everything
+ * else, and lying about a movement's difficulty is a different act from dragging a slider.
  */
 const DIFFICULTY_WEIGHT: Record<DifficultyCode, number> = {
-  easy: 0.85,
+  easy: 0.8,
   medium: 1.0,
-  hard: 1.25,
+  hard: 2.5,
 };
 
 /** The hero's chosen level. Distinct from `USER_LEVEL_MULTIPLIER`, which scales targets. */
@@ -105,7 +114,15 @@ export type ComputeSessionXpInput = {
   userLevel: DifficultyCode;
 };
 
-/** Weighted seconds of effort credited for one set. */
+/**
+ * Seconds of effort credited for one set, before the movement's weight.
+ *
+ * Raw and weighted are tracked apart on purpose: the effort ceiling is a bound on *physical*
+ * seconds — nobody trained longer than the session lasted — while the difficulty weight is a
+ * judgement about what a second was worth. Weighting first and clipping after would measure a
+ * value against a clock, and at `DIFFICULTY_WEIGHT.hard = 2.5` that clips every honest strength
+ * session, which is the opposite of why the weight is wide.
+ */
 function setEffortSeconds({ exercise, target, result }: XpSet): number {
   const done = Math.max(0, estimateExerciseSeconds(exercise, result));
   const allowed = Math.max(0, estimateExerciseSeconds(exercise, target)) * OVERSHOOT_ALLOWANCE;
@@ -120,7 +137,12 @@ function setEffortSeconds({ exercise, target, result }: XpSet): number {
       ? Math.min(done, allowed)
       : Math.min(done, allowed) + Math.max(0, done - allowed) * OVERSHOOT_DECAY;
 
-  return credited * DIFFICULTY_WEIGHT[exercise.difficulty];
+  return credited;
+}
+
+/** What that set is worth, once the movement it trained is taken into account. */
+function setWeightedSeconds(set: XpSet): number {
+  return setEffortSeconds(set) * DIFFICULTY_WEIGHT[set.exercise.difficulty];
 }
 
 /** Weighted effort seconds → XP. The tail every entry point shares. */
@@ -136,10 +158,19 @@ export function computeSessionXp({
   effortCeilingSeconds,
   userLevel,
 }: ComputeSessionXpInput): number {
-  const claimed = sets.reduce((sum, set) => sum + setEffortSeconds(set), 0);
-  const ceiling = Math.max(0, effortCeilingSeconds) * SPEED_ALLOWANCE;
+  const rawSeconds = sets.reduce((sum, set) => sum + setEffortSeconds(set), 0);
+  const weightedSeconds = sets.reduce((sum, set) => sum + setWeightedSeconds(set), 0);
 
-  return effortToXp(Math.min(claimed, ceiling), userLevel);
+  // The clock bounds the physical claim; whatever fraction of it survives, the weighted value
+  // keeps. Scaling rather than clipping is what lets a session of hard movements be worth more
+  // than its own duration without letting it claim more seconds than it lasted.
+  const ceiling = Math.max(0, effortCeilingSeconds) * SPEED_ALLOWANCE;
+  const credited =
+    rawSeconds > ceiling && rawSeconds > 0
+      ? weightedSeconds * (ceiling / rawSeconds)
+      : weightedSeconds;
+
+  return effortToXp(credited, userLevel);
 }
 
 export type EstimateQuestXpInput = {
@@ -162,7 +193,7 @@ export function estimateQuestXp(quest: EstimateQuestXpInput, userLevel: Difficul
   const perRound = quest.exercises.reduce(
     (sum, qex) =>
       sum +
-      setEffortSeconds({
+      setWeightedSeconds({
         exercise: qex.exercise,
         target: qex.target,
         result: { type: qex.target.type, value: qex.target.value * OVERSHOOT_ALLOWANCE },

--- a/db/xp.ts
+++ b/db/xp.ts
@@ -1,18 +1,174 @@
-import type { DifficultyCode } from "@/db/schema";
+import { estimateExerciseSeconds } from "./estimate";
+import type { Exercise } from "./exercises";
+import type { DifficultyCode } from "./schema";
+import type { Target } from "./targets";
+import { SECONDS_PER_REP_EQUIVALENT } from "./workUnits";
+
+/**
+ * XP measures the effort a session contained, not the time it spanned.
+ *
+ * It used to be `durationSeconds / 5` — wall-clock, nothing else. Rest counted, standing still
+ * counted, a backgrounded app counted, and a hero who set the rest slider to its 300s maximum
+ * out-earned one who trained: sitting paid exactly what working paid, for no effort. That is the
+ * bug this file exists to close, and `docs/gameplay/progression.md` already promised the fix —
+ * "XP, the village and the flame all measure how much and how often". Only the code disagreed.
+ *
+ * Effort is counted in seconds, at the catalogue's own tempo (`secondsPerRep`), which makes
+ * `estimateExerciseSeconds` the whole conversion: the function that estimates a quest's length
+ * from its targets estimates a set's effort from its result. Rate is one XP per
+ * `SECONDS_PER_REP_EQUIVALENT` — so 1 XP per rep at the default 3s tempo, and a minute of holds
+ * is worth a minute of reps.
+ *
+ * Deliberately *not* `toRepEquivalent`: that function's flat 3s conversion is what six seeded
+ * boss HP pools were tuned against (`drizzle/0026_boss_pacing.sql`, held by
+ * `__tests__/content-invariants.test.ts`). XP and damage answer different questions — effort
+ * spent versus blows landed, the latter with weakness, resistance and crits — so they keep
+ * different units and the bosses need no re-tune.
+ */
+
+/** Beating a target pays in full up to +25%. Past that, `OVERSHOOT_DECAY`. */
+export const OVERSHOOT_ALLOWANCE = 1.25;
+
+/**
+ * What effort past the allowance is worth — less, never nothing.
+ *
+ * A hard wall would tell the hero who did 15 pull-ups on a target of 10 that their last two were
+ * worth zero, which is the exact moment an app discourages its best user. The brake belongs at
+ * the session level (`MAX_SESSION_XP`), where it protects, not at the set level, where it punishes.
+ */
+export const OVERSHOOT_DECAY = 0.25;
+
+/**
+ * How much faster than the catalogue's tempo a hero is allowed to be before the clock stops
+ * believing them.
+ *
+ * Nobody can have exercised for more seconds than the session's effort window lasted, so this
+ * bound is physical rather than tuned — 1.2 is the slack for a hero who genuinely moves faster
+ * than `secondsPerRep` says. It is what makes tapping fifty sets through in twenty seconds worth
+ * twenty seconds, and it is a *ceiling* on effort, never a floor: waiting still earns nothing.
+ */
+export const SPEED_ALLOWANCE = 1.2;
+
+/**
+ * The one bound no hero input can raise.
+ *
+ * Rounds, targets, tempo, difficulty, declared results and elapsed time are all typed in by the
+ * hero, so any cap derived from them caps nothing — a quest of 10 rounds × 5 exercises × 999 reps
+ * has a "nominal" of fifty thousand. Sized at the honest ceiling instead: a hard 60-minute session
+ * with ~45 minutes of effort pays ~900, ×1.2 difficulty ×1.5 daily plus the two flat bonuses lands
+ * just under 2000. Unreachable by training, and the roof on everything else.
+ */
+export const MAX_SESSION_XP = 2000;
+
+/** No session is wasted — see `docs/gameplay/session-flow.md`. */
+const XP_FLOOR = 10;
+
+/**
+ * What a movement is worth per second of effort.
+ *
+ * Without it the optimal strategy is the easiest exercise in the catalogue: `toRepEquivalent` is
+ * flat, so fifty jumping jacks and fifty pull-ups weigh the same. Kept narrow on purpose — a hero
+ * can mark their own movement `hard` (`db/exercises.ts`, `createUserExercise`), and a 1.25×
+ * self-grant is not worth defending against.
+ */
+const DIFFICULTY_WEIGHT: Record<DifficultyCode, number> = {
+  easy: 0.85,
+  medium: 1.0,
+  hard: 1.25,
+};
+
+/** The hero's chosen level. Distinct from `USER_LEVEL_MULTIPLIER`, which scales targets. */
+const LEVEL_MULTIPLIER: Record<DifficultyCode, number> = {
+  easy: 0.9,
+  medium: 1.0,
+  hard: 1.2,
+};
+
+/** One set as XP reads it: what was asked, what was done, and by whom. */
+export type XpSet = {
+  exercise: Pick<Exercise, "secondsPerRep" | "difficulty">;
+  target: Target;
+  result: Target;
+};
 
 export type ComputeSessionXpInput = {
-  durationSeconds: number;
+  sets: XpSet[];
+  /**
+   * The session's elapsed time minus explicit pauses **and minus the rest actually taken** — the
+   * window in which effort could physically have happened.
+   *
+   * Rest has to come out, or camping the rest screen would inflate the very ceiling that
+   * fabricated results then fill. Rest *taken*, not rest *prescribed*: subtracting the prescription
+   * would push an honest hero who skips their rests below their own effort and floor them.
+   */
+  effortCeilingSeconds: number;
   userLevel: DifficultyCode;
 };
 
-export function computeSessionXp({ durationSeconds, userLevel }: ComputeSessionXpInput): number {
-  const s = Math.max(0, Math.round(durationSeconds));
+/** Weighted seconds of effort credited for one set. */
+function setEffortSeconds({ exercise, target, result }: XpSet): number {
+  const done = Math.max(0, estimateExerciseSeconds(exercise, result));
+  const allowed = Math.max(0, estimateExerciseSeconds(exercise, target)) * OVERSHOOT_ALLOWANCE;
 
-  // Baseline: 1 XP per 5 seconds (~12 XP/min) with a small floor.
-  const base = Math.max(10, Math.floor(s / 5));
+  // A hold's result *is* a clock: `ActiveExerciseView` records the elapsed seconds and overtime
+  // is unbounded, so a phone left face-up on a 30s plank declares two hours without anyone
+  // lying. Reps are typed by a hero who is present, so their overshoot earns the decaying tail;
+  // a hold's does not. The `longest_hold` record still keeps the true value — XP pays for the
+  // work prescribed, the record celebrates the feat.
+  const credited =
+    result.type === "time"
+      ? Math.min(done, allowed)
+      : Math.min(done, allowed) + Math.max(0, done - allowed) * OVERSHOOT_DECAY;
 
-  const multiplier = userLevel === "easy" ? 0.9 : userLevel === "hard" ? 1.2 : 1.0;
+  return credited * DIFFICULTY_WEIGHT[exercise.difficulty];
+}
 
-  // Keep XP in a sane range for early game.
-  return Math.min(5000, Math.max(0, Math.round(base * multiplier)));
+/** Weighted effort seconds → XP. The tail every entry point shares. */
+function effortToXp(effortSeconds: number, userLevel: DifficultyCode): number {
+  const xp =
+    (Math.max(0, effortSeconds) / SECONDS_PER_REP_EQUIVALENT) * LEVEL_MULTIPLIER[userLevel];
+
+  return Math.min(MAX_SESSION_XP, Math.max(XP_FLOOR, Math.round(xp)));
+}
+
+export function computeSessionXp({
+  sets,
+  effortCeilingSeconds,
+  userLevel,
+}: ComputeSessionXpInput): number {
+  const claimed = sets.reduce((sum, set) => sum + setEffortSeconds(set), 0);
+  const ceiling = Math.max(0, effortCeilingSeconds) * SPEED_ALLOWANCE;
+
+  return effortToXp(Math.min(claimed, ceiling), userLevel);
+}
+
+export type EstimateQuestXpInput = {
+  rounds: number;
+  exercises: Array<{ exercise: XpSet["exercise"]; target: Target }>;
+};
+
+/**
+ * What a quest is worth to a hero who beats every target by the full allowance — the "up to +N XP"
+ * the gallery and the quest screen advertise.
+ *
+ * It reads targets only, so it no longer moves when the rest slider does. That tag was how the
+ * rest exploit was found in the first place: dragging rest to 300s advertised +2940 XP, and the
+ * screen was telling the truth about a formula that should never have paid for waiting.
+ *
+ * No effort ceiling — an estimate has no clock yet, and this is an upper bound by construction.
+ */
+export function estimateQuestXp(quest: EstimateQuestXpInput, userLevel: DifficultyCode): number {
+  const rounds = Math.max(1, Math.round(quest.rounds));
+  const perRound = quest.exercises.reduce(
+    (sum, qex) =>
+      sum +
+      setEffortSeconds({
+        exercise: qex.exercise,
+        target: qex.target,
+        result: { type: qex.target.type, value: qex.target.value * OVERSHOOT_ALLOWANCE },
+      }),
+    0,
+  );
+
+  return effortToXp(rounds * perRound, userLevel);
 }

--- a/docs/architecture/database-api.md
+++ b/docs/architecture/database-api.md
@@ -426,55 +426,17 @@ interface Quest {
 
 ---
 
-## Resources
+## Resources — removed
 
-Fantasy resources earned through workouts.
+This section documented `getResourceInventory`, `addResources`, `spendResources`,
+`calculateSessionResources` and `getDifficultyMultiplier`. **None of those functions exist**, and
+none ever shipped: `grep getDifficultyMultiplier` returns nothing. The `resource_inventory` and
+`resource_transactions` tables are still in `db/schema.ts` and are read by no code at all.
 
-Product scope note: in MVP these resources are passive/read-only reward visibility. The DB exposes
-inventory and transaction helpers, including spending primitives, but Gold-first shops and manual
-village management are deferred product scope.
-
-### Types
-
-```typescript
-type ResourceCode =
-  | "gold" | "wood" | "stone" | "fire" | "water" | "wind" | "grain"
-  | "mana" | "leaf" | "boss_token";
-
-interface ResourceLoot {
-  resource: ResourceCode;
-  amount: number;
-  reason: string;  // Why earned
-}
-```
-
-### Muscle → Resource Mapping
-
-| Muscle | Resource |
-|--------|----------|
-| Arms | Wood 🪵 |
-| Back | Stone 🪨 |
-| Chest | Fire 🔥 |
-| Abs | Water 💧 |
-| Shoulders | Wind 🌬️ |
-| Legs (`calf` in schema) | Grain 🌾 |
-| Calisthenics style | Mana ✨ |
-| Yoga style | Leaf 🌿 |
-
-### Functions
-
-| Function | Description |
-|----------|-------------|
-| `getResourceInventory()` | Get all resource amounts |
-| `getResourceAmount(resource)` | Get single resource amount |
-| `addResources(loot[])` | Add resources to inventory |
-| `spendResources(resource, amount)` | Spend resources (returns success) |
-| `calculateSessionResources(exercises)` | Calculate loot from exercises |
-| `awardSessionResources(exercises)` | Calculate and add resources |
-| `previewSessionLoot(exercises)` | Preview loot without saving |
-| `getDifficultyMultiplier(difficulty)` | Get resource multiplier |
-
----
+Resources, Gold and boss tokens are a closed decision — see
+[roadmap.md](../planning/roadmap.md) §7 and
+[progression.md](../gameplay/progression.md)'s "What was removed, and why". The village is a pure
+function of the session journal; XP is the only currency.
 
 ## Rest Suggestions
 
@@ -582,25 +544,27 @@ Experience and leveling system.
 ```typescript
 interface UserLevelInfo {
   level: number;
-  title: string;          // "Novice", "Warrior", etc.
+  title: { en: string; fr: string };  // localised, one per level
   totalXp: number;
   currentLevelXp: number;
   xpToNextLevel: number;
-  progressPercent: number;
+  xpProgress: number;                 // 0-100
 }
 ```
 
 ### Level Titles
 
-| Level | Title (EN) |
-|-------|------------|
-| 1-4 | Novice |
-| 5-9 | Apprentice |
-| 10-14 | Warrior |
-| 15-19 | Champion |
-| 20-24 | Hero |
-| 25-29 | Legend |
-| 30+ | Immortal |
+**One title per level, not a band.** `db/userLevel.ts` keys 1→20 individually — Apprentice,
+Novice, Trainee, Squire, Warrior, Fighter, Veteran, Champion, Elite, Master, Grandmaster, Legend,
+Mythic, Titan, Demigod, Hero, Paragon, Ascended, Immortal, Divine — and everything past 20 is
+`Divine N`. This page previously showed bands ("1-4 Novice", "30+ Immortal") that never matched
+the code.
+
+### The curve
+
+Cumulative thresholds `50·n·(n−1)` up to level 20 (19 000 XP), then a flat 2 000 XP a level with
+no cap. At the ~300 XP an honest session pays (see
+[progression.md](../gameplay/progression.md)), level 20 is roughly 63 sessions.
 
 ### Functions
 

--- a/docs/gameplay/boss-fights.md
+++ b/docs/gameplay/boss-fights.md
@@ -115,9 +115,12 @@ If the kill is guaranteed either way, the fair question is what the pool still d
   card narrates the killing stroke (`boss.final_blow`) so "defeated at 300 HP" reads as the design
   it is, not a bug.
 
-Reward for pushing, never punishment for training under target. Detection is in-memory in
+Reward for pushing, never punishment for training under target. Detection is in
 `saveSession` (`payTriumphBonus`): the fight was alive at session start (a corpse is dropped at
-load), its pool hit zero, and `dealFinalBlow` had nothing left to do.
+load), its pool hit zero, and `dealFinalBlow` had nothing left to do. The payment is guarded by a
+`triumphBonusPaid` flag on the session store, because none of those conditions can tell a first
+attempt from a retry — by the time the bonus is due the pool is already empty in the database, so
+the victory screen's retry button used to pay it twice.
 
 **This is a ratchet.** `__tests__/content-invariants.test.ts` re-derives every campaign's total from
 the seeded quests at all three difficulties and fails if any boss survives its campaign or dies

--- a/docs/gameplay/progression.md
+++ b/docs/gameplay/progression.md
@@ -2,7 +2,7 @@
 title: Progression (XP, Village, Flame)
 type: system
 status: active
-updated: 2026-07-30
+updated: 2026-08-26
 related:
   [
     ../planning/roadmap.md,
@@ -11,7 +11,7 @@ related:
     coach-planning.md,
     ../raw/bodyweight-app-research.md,
   ]
-sources: [db/xp.ts, db/streaks.ts]
+sources: [db/xp.ts, db/streaks.ts, db/preview.ts]
 ---
 
 # Progression
@@ -39,6 +39,38 @@ DO WORKOUT → session journal entry (append-only)
 
 Every workout grants XP. Level is a running total → level curve. Level is the single number
 that drives the village's tier (below). Nothing else consumes or stores XP per-building.
+
+### XP measures effort, not elapsed time
+
+**One XP per three seconds of effort** — so one XP per rep at the catalogue's default 3s tempo,
+and a minute of holds is worth a minute of reps. Effort is read from what the hero logged, at each
+movement's own `secondsPerRep`, weighted by its difficulty (0.85 / 1.0 / 1.25). The hero's chosen
+level still scales the payout (×0.9 / ×1.0 / ×1.2), as the quest screen advertises.
+
+Three bounds, each answering a different question (`db/xp.ts`):
+
+| Bound | Value | What it answers |
+| --- | --- | --- |
+| Overshoot allowance | +25%, then 25% of the surplus | Beating a target pays, and keeps paying — it resists rather than stopping. Holds get no tail: a hold's result is a clock, so its overtime is not a claim anyone made. |
+| Effort ceiling | elapsed − pauses − **rest taken**, ×1.2 | Nobody exercised for more seconds than the window allowed. A ceiling, never a source. |
+| `MAX_SESSION_XP` | 2000 | The only bound no hero input can raise. Rounds, targets, tempo and results are all typed in, so a cap derived from them caps nothing. |
+
+Rest is not effort, and does not appear on either side: not in the payout, and not in the ceiling.
+
+#### Why it changed
+
+It used to be `durationSeconds / 5` — wall-clock and nothing else. Rest counted, waiting counted,
+a backgrounded app counted. A hero who dragged the rest slider to its 300s maximum out-earned one
+who trained, for no effort, and the gallery's "up to +N XP" chip advertised it: the tag moved with
+the slider, so the exploit was discoverable without reading a line of code.
+
+The fix is not a new design. This page already said XP measures *how much* — only the code
+disagreed. What the rewrite cost was the assumption that a clock is a proxy for work.
+
+`0037_xp_measures_effort.sql` is the one place the change reaches backwards. Journalled XP is left
+alone — nobody is demoted by an update — except for sessions whose XP has no relation to the work
+they recorded, because `most_xp` is a per-session record read live off the journal and the
+exploiting session would otherwise stand as an unbeatable trophy.
 
 ## Village
 

--- a/docs/gameplay/progression.md
+++ b/docs/gameplay/progression.md
@@ -42,10 +42,22 @@ that drives the village's tier (below). Nothing else consumes or stores XP per-b
 
 ### XP measures effort, not elapsed time
 
-**One XP per three seconds of effort** — so one XP per rep at the catalogue's default 3s tempo,
-and a minute of holds is worth a minute of reps. Effort is read from what the hero logged, at each
-movement's own `secondsPerRep`, weighted by its difficulty (0.85 / 1.0 / 1.25). The hero's chosen
-level still scales the payout (×0.9 / ×1.0 / ×1.2), as the quest screen advertises.
+**One XP per three seconds of effort** — so one XP per rep on a `medium` movement at the
+catalogue's default 3s tempo, and a minute of holds is worth a minute of reps. Effort is read from
+what the hero logged, at each movement's own `secondsPerRep`, then weighted by how hard that
+movement is: **easy 0.8 · medium 1.0 · hard 2.5**. The hero's chosen level scales the payout on top
+of that (×0.9 / ×1.0 / ×1.2), as the quest screen advertises.
+
+The hard weight is wide because a narrow one was measured against the seeded catalogue and found
+to punish the two archetypes it should reward. `skill` and `strength` quests are 80-87% rest *by
+protocol* — ten seconds of front lever, two minutes of recovery — so a volume metric undervalues
+them: at 0.85/1.0/1.25 they paid 0.31× and 0.51× of what the old clock paid, while `mobility` kept
+0.97×. A hard rep being worth roughly three easy ones is also simply true; one pull-up is not one
+jumping jack.
+
+Order matters between the weight and the ceiling below: the ceiling bounds *physical* seconds,
+the weight prices them. Weighting first would clip every honest session of hard movements against
+its own clock.
 
 Three bounds, each answering a different question (`db/xp.ts`):
 

--- a/drizzle/0037_xp_measures_effort.sql
+++ b/drizzle/0037_xp_measures_effort.sql
@@ -1,0 +1,53 @@
+-- L'XP mesurait l'horloge, pas le travail.
+--
+-- `computeSessionXp` valait `durationSeconds / 5` : le repos comptait, l'attente comptait, une app
+-- en arrière-plan comptait. Un héros qui poussait le curseur de repos à son maximum de 300 s
+-- gagnait plus qu'un héros qui s'entraînait, pour zéro effort. La formule lit désormais le travail
+-- journalisé (`db/xp.ts`), mais le journal, lui, garde ce que l'ancienne a payé.
+--
+-- On ne rejoue pas l'histoire : `xpEarned` est intact pour tout le monde, et personne ne se
+-- réveille rétrogradé. Sauf que `most_xp` est un record *par séance*, lu en direct par
+-- `MAX(xpEarned)` sur le journal (`db/personalRecords.ts`) : sans ce passage, la séance qui a
+-- exploité le bug reste le record « Most XP » à vie, affiché à celui qui a signalé le bug. C'est
+-- exactement le trophée que la triche visait.
+--
+-- Donc : uniquement les séances aberrantes, ramenées à une barre volontairement généreuse.
+--
+-- La barre est `3 × rep-équivalents journalisés` — la conversion de `db/workUnits.ts`, celle des
+-- dégâts de boss, et non la nouvelle formule complète. Aucune jointure sur `exercises` : le tempo
+-- et la difficulté du mouvement n'entrent pas ici, ce qui évite au passage la règle des deux
+-- populations (`0035`). Le facteur 3 couvre tout ce qu'une séance honnête pouvait légitimement
+-- cumuler sous l'ancienne formule — un mouvement lent (`secondsPerRep` 5 contre la médiane 3) plus
+-- le bonus ×1,5 de la quête du jour plafonnent vers 2,5. Une séance passée à attendre, elle, a un
+-- rapport sans borne.
+--
+-- Une séance sans exercice ne peut pas exister (`createCompletedSession` lève), donc la sous-
+-- requête ne rend jamais NULL sur une ligne que le WHERE a retenue.
+
+UPDATE `completed_sessions`
+SET `xpEarned` = MAX(
+  10,
+  3 * (
+    SELECT SUM(
+      CASE WHEN `ce`.`resultType` = 'time'
+           THEN MAX(1, CAST(ROUND(`ce`.`resultValue` * 1.0 / 3) AS INTEGER))
+           ELSE `ce`.`resultValue`
+      END
+    )
+    FROM `completed_exercises` AS `ce`
+    WHERE `ce`.`sessionId` = `completed_sessions`.`id`
+  )
+)
+WHERE `xpEarned` > MAX(
+  10,
+  3 * (
+    SELECT SUM(
+      CASE WHEN `ce`.`resultType` = 'time'
+           THEN MAX(1, CAST(ROUND(`ce`.`resultValue` * 1.0 / 3) AS INTEGER))
+           ELSE `ce`.`resultValue`
+      END
+    )
+    FROM `completed_exercises` AS `ce`
+    WHERE `ce`.`sessionId` = `completed_sessions`.`id`
+  )
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1787115600000,
       "tag": "0036_hero_names_are_theirs",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1787119200000,
+      "tag": "0037_xp_measures_effort",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -37,6 +37,7 @@ import m0033 from "./0033_calisthenics_summits.sql";
 import m0034 from "./0034_quest_round_rest.sql";
 import m0035 from "./0035_hero_exercises.sql";
 import m0036 from "./0036_hero_names_are_theirs.sql";
+import m0037 from "./0037_xp_measures_effort.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -79,5 +80,6 @@ export default {
     m0034,
     m0035,
     m0036,
+    m0037,
   },
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -469,6 +469,7 @@
     "village_growth_more": "+{{count}} more",
     "village_growth_title": "Your village grows",
     "village_tier_up_title": "Your village grew!",
+    "xp_overshoot": "incl. +{{count}} for beating your targets",
     "xp_earned": "XP Earned",
     "warmup_title": "WARM-UP",
     "warmup_skip": "Skip warm-up",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -667,6 +667,7 @@
     "village_growth_more": "+{{count}} autres",
     "village_growth_title": "Ton village grandit",
     "village_tier_up_title": "Ton village a grandi !",
+    "xp_overshoot": "dont +{{count}} pour avoir dépassé vos cibles",
     "xp_earned": "XP gagnés",
     "warmup_title": "ÉCHAUFFEMENT",
     "warmup_skip": "Passer l'échauffement",

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -20,13 +20,15 @@ import {
   getSessionAggregates,
   markSessionWithNewRecords,
 } from "@/db/completed";
+import { estimateQuestSeconds } from "@/db/estimate";
 import { checkForNewRungs, type VariationStep } from "@/db/exercises";
 import { checkOathFulfilled, OATH_XP_BONUS, type OathProgress } from "@/db/oaths";
 import { checkForNewRecords, type NewRecordResult } from "@/db/personalRecords";
 import { preferences } from "@/db/preferences";
 import { clearShortLivedQueries } from "@/db/queryCache";
+import { REST_RANGE, TARGET_RANGE } from "@/db/questConfig";
 import { isDailyQuest, type Quest } from "@/db/quests";
-import type { DifficultyCode, FeedbackCode, MuscleCode } from "@/db/schema";
+import type { DifficultyCode, FeedbackCode, MuscleCode, QuestTargetType } from "@/db/schema";
 import { updateStreakAfterSession } from "@/db/streaks";
 import { calculateLevelFromXp, getTotalXp } from "@/db/userLevel";
 import {
@@ -36,7 +38,7 @@ import {
   type VillageGrowth,
   type VillageTierUp,
 } from "@/db/village";
-import { computeSessionXp } from "@/db/xp";
+import { computeSessionXp, MAX_SESSION_XP, type XpSet } from "@/db/xp";
 import { reportError } from "@/src/reportError";
 import { requestWidgetsUpdate } from "@/src/widget";
 
@@ -50,6 +52,25 @@ export type SessionStatus =
   | "finished";
 
 const PRE_START_COUNTDOWN_SECONDS = 3;
+
+/** Ceiling on one hold. An hour in a single set is past any prescription this app can write. */
+const MAX_HOLD_SECONDS = 3600;
+
+/**
+ * What one set may claim.
+ *
+ * The database only demands `> 0`, so an absurd value used to flow straight into muscle volume,
+ * the village's building levels, the journal's balance card and the personal records — none of
+ * which `MAX_SESSION_XP` covers, because that caps XP and nothing else. Clamped here, where the
+ * `max(1, ...)` guard the DB constraints already required lives, so every consumer of a result is
+ * bounded by construction rather than by each caller remembering.
+ */
+function clampResultValue(resultValue: number, type: QuestTargetType): number {
+  if (!Number.isFinite(resultValue)) return 1;
+
+  const ceiling = type === "time" ? MAX_HOLD_SECONDS : TARGET_RANGE.max;
+  return Math.min(ceiling, Math.max(1, Math.floor(resultValue)));
+}
 
 interface SessionState {
   // Static Data
@@ -104,6 +125,18 @@ interface SessionState {
   startTime: number | null; // Date.now() when session started
   totalPausedTime: number; // Accumulator for pause duration
   lastPauseTimestamp: number | null; // Date.now() when pause started
+  /**
+   * Rest actually taken between sets, in seconds — banked when the rest screen is left.
+   *
+   * XP is paid for effort, and the ceiling that bounds a session's claimed effort is the window
+   * in which effort could have happened. Rest is not that window: leaving it in would let a hero
+   * camp the rest screen to inflate the very ceiling fabricated results then fill, which is the
+   * original bug wearing a different hat.
+   *
+   * Measured, never prescribed. Subtracting the configured rest instead would push a hero who
+   * skips their rests below their own effort and floor them for training harder.
+   */
+  restTakenSeconds: number;
 
   // Active Timer (for Time-based exercises or Rest)
   timerStartTimestamp: number | null; // Date.now() when current timer started
@@ -117,6 +150,15 @@ interface SessionState {
    * resumes that session instead of banking a second one.
    */
   savedSessionId: number | null;
+  /**
+   * Whether this session already paid the Triumph bonus.
+   *
+   * Not derivable from the boss: by the time the bonus is paid the pool is already empty in the
+   * database, so a retry re-reading the fight sees exactly what the first pass saw and pays again.
+   * The only fact that distinguishes them is this one, and it lives beside `savedSessionId`
+   * because it answers the same question about a different write.
+   */
+  triumphBonusPaid: boolean;
 
   // Actions
   startSession: (
@@ -152,6 +194,8 @@ interface SessionState {
     newAchievements: NewAchievementResult[];
     fulfilledOath: OathProgress | null;
     oathBonusXp: number;
+    /** Of `xpEarned`, how much came from beating targets rather than meeting them. */
+    overshootXp: number;
     campaign: {
       adventureId: number;
       runId: number;
@@ -194,10 +238,27 @@ export type SavedSessionState = Pick<
   | "currentExerciseIndex"
   | "startTime"
   | "totalPausedTime"
+  | "restTakenSeconds"
   | "timerStartTimestamp"
   | "timerDuration"
   | "results"
 > & { savedAt: number };
+
+/**
+ * The session's results paired back with the movements that produced them.
+ *
+ * `sortOrder` is the slot index `completeExercise` recorded, so the join is exact even when a
+ * quest repeats an exercise or a config swapped one out. A result whose slot has vanished is
+ * dropped rather than guessed at — it cannot be priced without knowing what was asked.
+ */
+function toXpSets(quest: Quest, results: CompletedExerciseInput[]): XpSet[] {
+  return results.flatMap((r) => {
+    const slot = quest.exercises[r.sortOrder];
+    if (!slot) return [];
+
+    return [{ exercise: slot.exercise, target: r.target ?? slot.target, result: r.result }];
+  });
+}
 
 /**
  * The row for this save, created once however many times `saveSession` runs.
@@ -285,7 +346,13 @@ async function payTriumphBonus(
   sessionId: number,
 ): Promise<number> {
   if (!bossFight || bossFight.currentHp > 0 || finalBlow) return 0;
+  // `saveSession` is a dozen awaits long and the victory screen retries it on failure. Every
+  // condition above is unchanged between attempts — the pool is empty in the database by then —
+  // so without this flag a retry pays the Triumph a second time.
+  if (useSessionStore.getState().triumphBonusPaid) return 0;
+
   await addBonusXpToSession(sessionId, TRIUMPH_XP_BONUS);
+  useSessionStore.setState({ triumphBonusPaid: true });
   return TRIUMPH_XP_BONUS;
 }
 
@@ -333,11 +400,13 @@ export const useSessionStore = create<SessionState>()(
     currentExerciseIndex: 0,
     startTime: null,
     totalPausedTime: 0,
+    restTakenSeconds: 0,
     lastPauseTimestamp: null,
     timerStartTimestamp: null,
     timerDuration: 0,
     results: [],
     savedSessionId: null,
+    triumphBonusPaid: false,
 
     startSession: async (quest, userLevel, options) => {
       // Load boss fight if this is a boss adventure. Callers only ever hold the run step id —
@@ -378,6 +447,7 @@ export const useSessionStore = create<SessionState>()(
         currentExerciseIndex: 0,
         startTime: Date.now(),
         totalPausedTime: 0,
+        restTakenSeconds: 0,
         lastPauseTimestamp: null,
         // Warm-up step, or the full-screen 3..2..1. Exercise timers start after the countdown.
         timerStartTimestamp: Date.now(),
@@ -386,6 +456,7 @@ export const useSessionStore = create<SessionState>()(
           : PRE_START_COUNTDOWN_SECONDS,
         results: [],
         savedSessionId: null,
+        triumphBonusPaid: false,
       });
     },
 
@@ -537,11 +608,13 @@ export const useSessionStore = create<SessionState>()(
         currentExerciseIndex: 0,
         startTime: null,
         totalPausedTime: 0,
+        restTakenSeconds: 0,
         lastPauseTimestamp: null,
         timerStartTimestamp: null,
         timerDuration: 0,
         results: [],
         savedSessionId: null,
+        triumphBonusPaid: false,
       });
     },
 
@@ -550,14 +623,13 @@ export const useSessionStore = create<SessionState>()(
       const { quest, currentRoundIndex, currentExerciseIndex, results, bossFight } = get();
       if (!quest) return;
 
-      // DB constraints (see migrations) require: resultValue > 0, roundIndex >= 0, sortOrder >= 0.
-      // Guard against accidental 0/NaN when users tap "DONE" immediately on time-based exercises.
-      const safeResultValue = Number.isFinite(resultValue)
-        ? Math.max(1, Math.floor(resultValue))
-        : 1;
-
       const currentEx = quest.exercises[currentExerciseIndex];
       if (!currentEx) return;
+
+      // DB constraints (see migrations) require: resultValue > 0, roundIndex >= 0, sortOrder >= 0.
+      // Guards accidental 0/NaN when users tap "DONE" immediately on time-based exercises, and
+      // the ceiling above.
+      const safeResultValue = clampResultValue(resultValue, currentEx.target.type);
 
       // Land the hit on the fight we hold, and bank it. Nothing reaches the database until
       // saveSession: see `pendingDamage`. This is pure maths now, so there is no failure to
@@ -664,14 +736,23 @@ export const useSessionStore = create<SessionState>()(
     },
 
     skipRest: () => {
-      const { status, quest, currentExerciseIndex } = get();
+      const { status, quest, currentExerciseIndex, timerStartTimestamp, restTakenSeconds } = get();
       if (status !== "resting" || !quest) return;
 
       const nextExDef = quest.exercises[currentExerciseIndex];
       const isNextTimeBased = nextExDef?.target.type === "time";
 
+      // The single exit from `resting` — the skip button and RestView's auto-advance at 0:00 both
+      // land here — so it is the one place rest gets measured. `timerStartTimestamp` is pushed
+      // forward by `resumeSession`, so a pause taken mid-rest is already excluded and cannot be
+      // subtracted twice.
+      const restTaken = timerStartTimestamp
+        ? Math.max(0, (Date.now() - timerStartTimestamp) / 1000)
+        : 0;
+
       set({
         status: "running",
+        restTakenSeconds: restTakenSeconds + restTaken,
         timerStartTimestamp: isNextTimeBased ? Date.now() : null,
         timerDuration: isNextTimeBased ? nextExDef.target.value : 0,
       });
@@ -680,7 +761,9 @@ export const useSessionStore = create<SessionState>()(
     addRestTime: (seconds) => {
       const { status, timerDuration } = get();
       if (status !== "resting") return;
-      set({ timerDuration: timerDuration + seconds });
+      // Same ceiling the quest editor and the config card enforce. Without it "+30s" stacked
+      // forever and the rest screen had no way out but the skip button.
+      set({ timerDuration: Math.min(REST_RANGE.max, timerDuration + seconds) });
     },
 
     updateLastResult: (resultValue) => {
@@ -689,9 +772,7 @@ export const useSessionStore = create<SessionState>()(
       if (!last) return;
 
       // DB constraints require resultValue > 0.
-      const safeResultValue = Number.isFinite(resultValue)
-        ? Math.max(1, Math.floor(resultValue))
-        : 1;
+      const safeResultValue = clampResultValue(resultValue, last.result.type);
       const updated = {
         ...last,
         result: { ...last.result, value: safeResultValue },
@@ -746,6 +827,7 @@ export const useSessionStore = create<SessionState>()(
         userLevel,
         startTime,
         totalPausedTime,
+        restTakenSeconds,
         results,
         adventureRunStepId,
         bossFight,
@@ -753,8 +835,35 @@ export const useSessionStore = create<SessionState>()(
       } = get();
       if (!quest || !startTime) throw new Error("No active session");
 
-      const durationSeconds = Math.floor((Date.now() - startTime - totalPausedTime) / 1000);
-      let xpEarned = computeSessionXp({ durationSeconds, userLevel });
+      const measuredSeconds = Math.floor((Date.now() - startTime - totalPausedTime) / 1000);
+
+      // Nothing pauses when the app goes to the background — there is no `AppState` listener in
+      // this project — so a session left open overnight measures nine hours, takes the
+      // "longest session" record and unlocks both long-session achievements. XP no longer reads
+      // this as a source, but `checkForNewRecords` and `checkForNewAchievements` still do.
+      // ponytail: twice the quest's own estimate is the ceiling. A real session that genuinely
+      //           runs past it loses the surplus from its journal entry only; if anyone ever
+      //           reports that, the fix is an AppState listener that banks background time as
+      //           pause, not a bigger multiplier.
+      const durationSeconds = Math.min(measuredSeconds, estimateQuestSeconds(quest) * 2);
+
+      // XP is paid for the work in `results`; the clock only says how much of it could have been
+      // real. Rest comes out of that window along with explicit pauses — otherwise camping the
+      // rest screen raises the ceiling that fabricated results then fill, which is the very bug
+      // this replaced. Clamped at zero: a hero who skips every rest still gets their own effort.
+      const effortCeilingSeconds = Math.max(0, durationSeconds - restTakenSeconds);
+      const sets = toXpSets(quest, results);
+      let xpEarned = computeSessionXp({ sets, effortCeilingSeconds, userLevel });
+
+      // What the same session would have paid for hitting every target exactly. The difference is
+      // the reward for going past them — surfaced on the victory screen, because an allowance the
+      // hero cannot see reads as a ceiling that ate their last few reps.
+      const xpAtTarget = computeSessionXp({
+        sets: sets.map((set) => ({ ...set, result: set.target })),
+        effortCeilingSeconds,
+        userLevel,
+      });
+      let overshootXp = Math.max(0, xpEarned - xpAtTarget);
 
       // Snapshot before this session's exercises land, so the village-growth diff at the
       // end reflects exactly what this save changed.
@@ -763,6 +872,7 @@ export const useSessionStore = create<SessionState>()(
       const dailyBonusApplied = await isDailyQuest(quest.id);
       if (dailyBonusApplied) {
         xpEarned = Math.round(xpEarned * 1.5);
+        overshootXp = Math.round(overshootXp * 1.5);
       }
 
       // Calculate level before saving (current state)
@@ -845,6 +955,12 @@ export const useSessionStore = create<SessionState>()(
       // and the level pick it up with no extra state.
       xpEarned += await payTriumphBonus(bossFight, finalBlow, sessionId);
 
+      // The ceiling belongs here, not inside `computeSessionXp`: the daily ×1.5 and the two flat
+      // bonuses land after it, and a cap applied before them capped nothing — the old `min(5000)`
+      // let a session reach 7850. Everything that can add XP has now been added.
+      xpEarned = Math.min(MAX_SESSION_XP, xpEarned);
+      overshootXp = Math.min(overshootXp, xpEarned);
+
       // Level after all XP (base + any oath bonus) is settled.
       const newTotalXp = oldTotalXp + xpEarned;
       const newLevel = calculateLevelFromXp(newTotalXp);
@@ -875,6 +991,7 @@ export const useSessionStore = create<SessionState>()(
         newAchievements,
         fulfilledOath,
         oathBonusXp,
+        overshootXp,
         campaign,
         levelUp,
         heroXp: { before: oldTotalXp, after: newTotalXp },
@@ -944,6 +1061,7 @@ useSessionStore.subscribe(
           currentExerciseIndex: state.currentExerciseIndex,
           startTime: state.startTime,
           totalPausedTime: state.totalPausedTime,
+          restTakenSeconds: state.restTakenSeconds,
           timerStartTimestamp: state.timerStartTimestamp,
           timerDuration: state.timerDuration,
           results: state.results,


### PR DESCRIPTION
## Le rapport

> *"me and my brother are competing to see who can get most XP and my brother found that longer break time gives you XP, so if I have a 300 minute break it gives me a lot of XP — could you please fix that thanks"*

Le symptôme nomme une seule ligne. [`db/xp.ts`](db/xp.ts) valait `durationSeconds / 5` : ni reps, ni volume, ni cibles atteintes — l'horloge, et rien d'autre. Le repos n'était pas *un* trou dans la formule ; la formule mesurait le temps, et le repos en est.

Conséquence : **attendre était strictement meilleur que s'entraîner.** Même taux, zéro effort.

Et l'aperçu l'enseignait à voix haute. La vignette « up to +N XP » lisait `estimateQuestSeconds`, repos compris : glisser le curseur à son maximum de 300 s affichait **+2 940 XP**. Le frère n'a pas lu le code, il a lu l'interface.

Ce n'était même pas le design voulu — [`docs/gameplay/progression.md`](docs/gameplay/progression.md) promettait déjà *« XP, the village and the flame all measure how much and how often »*. Seul le code divergeait.

## Le correctif

L'XP compte des **secondes d'effort** au tempo du catalogue, pondérées par la difficulté du mouvement. Un XP par trois secondes — soit un XP par rep au tempo par défaut. `estimateExerciseSeconds` existait déjà : il est désormais appelé avec le *résultat* au lieu de la *cible*. Zéro arithmétique nouvelle.

Trois bornes, chacune pour une question distincte :

| Borne | Valeur | Ce qu'elle répond |
|---|---|---|
| Dépassement | +25 %, puis 25 % du surplus | Battre sa cible paie, et continue de payer — ça résiste, ça ne bloque pas. Les tenues n'ont pas la queue dégressive : leur résultat *est* une horloge. |
| Plafond d'effort | `(écoulé − pauses − repos mesuré) × 1,2` | Personne ne s'est entraîné plus de secondes que la fenêtre n'en contenait. Un plafond, jamais une source. |
| `MAX_SESSION_XP` | 2 000, après les bonus | La seule borne qu'aucune saisie du héros ne relève. L'ancien `min(5000)` s'appliquait *avant* le ×1,5 et laissait passer 7 850. |

`toRepEquivalent` n'est pas touchée : elle porte les pools des six boss semés en `0026`. L'XP et les dégâts répondent à deux questions différentes — effort dépensé contre coups portés.

## Trois versions ont failli livrer pire que le bug

Chacune est maintenant un test nommé dans [`__tests__/xp.test.ts`](__tests__/xp.test.ts) :

- **Un plafond « nominal × 1,25 »** — dérivé de rounds et cibles que le héros saisit lui-même. Une quête maison de 10 × 5 × 999 aurait payé **62 437 XP**, vingt fois l'exploit visé.
- **Payer le travail déclaré sans borne physique** — 50 sets tapés en 20 secondes, soit 900 fois moins cher que l'exploit d'origine.
- **Créditer le dépassement d'une tenue** — `ActiveExerciseView` enregistre l'écoulé et l'overtime est illimité, donc un téléphone posé sur une planche de 30 s déclarait deux heures sans mentir.

Le PR « longest hold » garde la vraie valeur : **l'XP paie le travail prévu, le record célèbre l'exploit.**

## Le calibrage a corrigé mes suppositions

Mesuré sur le catalogue seedé, un poids de difficulté étroit (0,85 / 1,0 / 1,25) donnait `skill` à **0,31×** et `strength` à **0,51×** : ces quêtes sont à 80-87 % de repos *par protocole*, et toute métrique de volume les sous-évalue. Punir le skill de 70 % pousse à l'éviter.

`DIFFICULTY_WEIGHT` passe donc à **0,8 / 1,0 / 2,5**. Ce changement a révélé un bug dimensionnel : le poids était appliqué **avant** le plafond physique, ce qui à 2,5 aurait découpé chaque séance de force honnête. Le plafond borne des secondes réelles, le poids les valorise — les deux sommes sont suivies séparément et le plafond met à l'échelle au lieu de tronquer.

Simulation, héros honnête aux cibles atteintes : **easy 83 · medium 123 · hard 185** par séance. Niveau 20 en 52 semaines à trois séances hebdomadaires.

## Le même motif, trouvé trois fois

`restSeconds`, `rounds`, les cibles et `secondsPerRep` n'étaient bornés que par les steppers de l'UI — les writers prenaient la valeur brute. Ils clampent désormais. `resultValue` aussi, à la source : un chiffre délirant nourrissait le volume du village, la balance musculaire et les records, qu'aucun plafond d'XP ne couvre.

`SECONDS_PER_REP_RANGE` passe de 30 à 10 : le catalogue seedé va de 1 à 5, et au-delà de 10 ce n'est plus une répétition mais une tenue — qui a son propre type de cible, mesuré plutôt que déclaré.

## Le Triomphe payé deux fois

`payTriumphBonus` ne testait que le HP **en mémoire**, inchangé entre deux tentatives, et l'écran de victoire rejoue `saveSession` en cas d'échec. Une relecture en base ne suffit pas : à ce moment le pool est déjà vide, donc le premier passage et le retry voient la même chose. Un drapeau de séance, à côté de `savedSessionId` qui répond à la même question sur une autre écriture.

## Migration `0037`

Le seul endroit où le changement regarde en arrière. L'XP journalisée est intacte — personne ne se réveille rétrogradé — **sauf** les séances dont l'XP n'a aucun rapport avec le travail qu'elles enregistrent.

Nécessaire parce que `most_xp` est un record par séance lu en direct sur le journal : sans ça, la séance de la triche restait un trophée imbattable **dans l'app de celui qui a signalé le bug**. La barre est volontairement généreuse (trois fois les rep-équivalents journalisés) et la migration est testée contre une base réelle, idempotence comprise.

## Vérification

- `npm test` — **936 tests**, `db/xp.ts` à **100 %** sur les quatre métriques, tous les seuils de couverture tenus
- `biome check --error-on-warnings .` et `tsc --noEmit` propres sur tout le dépôt
- `npm run deadcode` (knip) vide
- `npx expo-doctor` 20/20
- `__tests__/content-invariants.test.ts` vert **sans modification** — la preuve que les pools de boss n'ont pas bougé

## Reste ouvert

`TRIUMPH_XP_BONUS` vaut 100 quand le serment vaut 250, alors que le code *et* la doc affirmaient « twice the oath's bonus ». Seule l'affirmation est corrigée ici — le chiffre est un arbitrage. Chiffré : abattre l'Iron Lord, campagne de 8 séances valant 1 968 XP, paie +100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)