### PR TITLE
fix(quests): serve the rung the hero is on (#33)

### DIFF
--- a/__tests__/content-invariants.test.ts
+++ b/__tests__/content-invariants.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { type DifficultyCode, movementPatterns, type QuestArchetype } from "../db/schema";
-import { clientMock, createTestDb } from "./helpers/testDb";
+import { clientMock, createTestDb, ownEveryRung } from "./helpers/testDb";
 
 /**
  * Content invariants — the hard constraints every seeded quest has to satisfy. This file is
@@ -81,6 +81,8 @@ describe("content invariants", () => {
 
   async function loadQuests() {
     const quests = require("../db/quests") as typeof import("../db/quests");
+    ownEveryRung(t);
+    quests.invalidateQuestTemplates();
     const templates = await quests.listQuestTemplates();
 
     const loaded = await Promise.all(

--- a/__tests__/db-quest-config.test.ts
+++ b/__tests__/db-quest-config.test.ts
@@ -2,11 +2,14 @@ import assert from "node:assert/strict";
 
 import type { Quest } from "@/db/quests";
 import { Difficulty } from "@/db/targets";
-import { clientMock, createTestDb } from "./helpers/testDb";
+import { clientMock, createTestDb, ownEveryRung } from "./helpers/testDb";
 
 // questConfig reaches the preferences table, which pulls in the native client: the same
 // mock every other db test uses keeps this one honest about what it imports.
 const t = createTestDb();
+
+// The quest as authored, not as prescribed to a day-one beginner — see `ownEveryRung`.
+ownEveryRung(t);
 
 jest.resetModules();
 jest.doMock("../db/client", () => clientMock(t));

--- a/__tests__/db-quest-substitution.test.ts
+++ b/__tests__/db-quest-substitution.test.ts
@@ -1,0 +1,132 @@
+import { clientMock, createTestDb } from "./helpers/testDb";
+
+/**
+ * Issue #33 — a beginner did wall push-ups on day one, and "Chop Wood" handed them classical
+ * push-ups on day two. They entered "1", the lowest the field accepts, and went off to do incline
+ * push-ups instead.
+ *
+ * `getQuestById` now serves the rung the hero is actually working. These tests are about the
+ * prescription, not the ladder itself — `db-progression.test.ts` owns that.
+ */
+describe("db/quests — a slot serves the rung the hero stands on", () => {
+  const t = createTestDb();
+
+  beforeAll(() => {
+    jest.resetModules();
+    jest.doMock("../db/client", () => clientMock(t));
+  });
+
+  afterEach(() => {
+    t.sqlite.exec("DELETE FROM completed_exercises");
+    t.sqlite.exec("DELETE FROM completed_sessions");
+    questsApi().invalidateQuestTemplates();
+  });
+
+  afterAll(() => t.close());
+
+  function questsApi() {
+    return require("../db/quests") as typeof import("../db/quests");
+  }
+
+  function idOf(enName: string): number {
+    return (
+      t.sqlite.prepare("SELECT id FROM exercises WHERE enName = ?").get(enName) as { id: number }
+    ).id;
+  }
+
+  function questIdOf(enTitle: string): number {
+    return (
+      t.sqlite.prepare("SELECT id FROM quests WHERE enTitle = ?").get(enTitle) as { id: number }
+    ).id;
+  }
+
+  /** One on-target session on `exerciseId`. Three of these earn the rung. */
+  function logOnTarget(exerciseId: number, daysAgo = 0): void {
+    const at = Math.floor(Date.now() / 1000) - daysAgo * 24 * 60 * 60;
+    const info = t.sqlite
+      .prepare(
+        "INSERT INTO completed_sessions (userLevel, xpEarned, performedAt) VALUES ('medium', 10, ?)",
+      )
+      .run(at);
+    t.sqlite
+      .prepare(
+        `INSERT INTO completed_exercises
+           (sessionId, exerciseId, roundIndex, sortOrder, resultType, resultValue, targetType,
+            targetValue, performedAt)
+         VALUES (?, ?, 0, 0, 'reps', 10, 'reps', 10, ?)`,
+      )
+      .run(Number(info.lastInsertRowid), exerciseId, at);
+  }
+
+  const pushUpSlot = async (questTitle = "Chop Wood") => {
+    const quest = await questsApi().getQuestById(questIdOf(questTitle), "medium");
+    return quest?.exercises.find(
+      (qex) => qex.exercise.enName === "Push-ups" || qex.substitutedFor?.enName === "Push-ups",
+    );
+  };
+
+  /**
+   * The report, replayed with its own numbers. `PROGRESSION_SESSIONS_REQUIRED` is 3; on day two
+   * the hero has *one* wall push-up session, so they are standing on the bottom rung — and that
+   * is what the quest must hand them. Word for word what they asked for: "wall push-ups again".
+   */
+  test("day two of the bug report: the push-up slot serves Wall Push-Up", async () => {
+    logOnTarget(idOf("Wall Push-Up"), 1);
+
+    const slot = await pushUpSlot();
+
+    expect(slot?.exercise.enName).toBe("Wall Push-Up");
+    expect(slot?.substitutedFor?.enName).toBe("Push-ups");
+  });
+
+  test("a hero with no history at all is not handed the top of the chain either", async () => {
+    const slot = await pushUpSlot();
+
+    expect(slot?.exercise.enName).toBe("Wall Push-Up");
+  });
+
+  /** Earn every rung below, and the quest reads as written — no caption, no substitution. */
+  test("once the rungs below are owned, the written movement is served", async () => {
+    for (const day of [1, 2, 3]) logOnTarget(idOf("Wall Push-Up"), day);
+    for (const day of [4, 5, 6]) logOnTarget(idOf("Knee Push-Up"), day);
+
+    const slot = await pushUpSlot();
+
+    expect(slot?.exercise.enName).toBe("Push-ups");
+    expect(slot?.substitutedFor).toBeUndefined();
+  });
+
+  test("a substituted slot is priced and tagged as the movement that will actually run", async () => {
+    logOnTarget(idOf("Wall Push-Up"), 1);
+
+    const slot = await pushUpSlot();
+
+    // The session prices XP by these two, and the village counts the muscles. Reading them off
+    // the written movement would price wall push-ups as classical ones.
+    expect(slot?.exercise.difficulty).toBe("easy");
+    expect(slot?.exercise.muscles.length).toBeGreaterThan(0);
+    // The quest's own art is of the movement the template wrote.
+    expect(slot?.images).toEqual([]);
+  });
+
+  test("a quest the hero authored is served exactly as they wrote it", async () => {
+    logOnTarget(idOf("Wall Push-Up"), 1);
+
+    const info = t.sqlite
+      .prepare(
+        "INSERT INTO quests (enTitle, frTitle, enDescription, frDescription, author, rounds, restSeconds) VALUES ('Mine', 'Mine', '', '', 'hero', 1, 30)",
+      )
+      .run();
+    const questId = Number(info.lastInsertRowid);
+    t.sqlite
+      .prepare(
+        "INSERT INTO quest_exercises (questId, exerciseId, sortOrder, targetType, targetMin, targetMax, imagesJson) VALUES (?, ?, 0, 'reps', 8, 12, '[]')",
+      )
+      .run(questId, idOf("Push-ups"));
+
+    const quest = await questsApi().getQuestById(questId, "medium");
+
+    expect(quest?.exercises[0]?.exercise.enName).toBe("Push-ups");
+    expect(quest?.exercises[0]?.substitutedFor).toBeUndefined();
+  });
+});

--- a/__tests__/db-quests.test.ts
+++ b/__tests__/db-quests.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { clientMock, createTestDb } from "./helpers/testDb";
+import { clientMock, createTestDb, ownEveryRung } from "./helpers/testDb";
 
 describe("db/quests", () => {
   const t = createTestDb();
@@ -8,6 +8,14 @@ describe("db/quests", () => {
   beforeAll(() => {
     jest.resetModules();
     jest.doMock("../db/client", () => clientMock(t));
+  });
+
+  // The journal decides which rung a slot is served at, so a test that seeds it must not leak
+  // into the next one — and the resolved quest is memoized per (id, level) with no TTL.
+  afterEach(() => {
+    t.sqlite.exec("DELETE FROM completed_exercises");
+    t.sqlite.exec("DELETE FROM completed_sessions");
+    (require("../db/quests") as typeof import("../db/quests")).invalidateQuestTemplates();
   });
 
   afterAll(() => {
@@ -60,6 +68,10 @@ describe("db/quests", () => {
   });
 
   test("getQuestById computes targets from user level", async () => {
+    // Assert the movements the template names, so own every rung: on an empty journal a slot is
+    // served at the bottom of its chain (issue #33), which has its own file.
+    ownEveryRung(t);
+
     const quests = require("../db/quests") as typeof import("../db/quests");
 
     const templates = await quests.listQuestTemplates();

--- a/__tests__/helpers/testDb.ts
+++ b/__tests__/helpers/testDb.ts
@@ -69,6 +69,37 @@ export function clientMock(t: { db: unknown }) {
   };
 }
 
+/**
+ * Log three on-target sessions on every movement, so `getQuestById` serves each quest exactly as
+ * the content team wrote it.
+ *
+ * Since issue #33 a slot is served at the rung the hero is standing on, and on an empty journal
+ * that is the bottom of every chain. A test about target maths, swaps or catalogue invariants
+ * would otherwise be reading what a day-one beginner is prescribed instead of what was authored.
+ * Owning everything is the shortest way to say "not that hero" — the substitution has its own file.
+ */
+export function ownEveryRung(t: { sqlite: Database.Database }): void {
+  const ids = t.sqlite.prepare("SELECT id FROM exercises").all() as Array<{ id: number }>;
+  const at = Math.floor(Date.now() / 1000);
+  const session = t.sqlite.prepare(
+    "INSERT INTO completed_sessions (userLevel, xpEarned, performedAt) VALUES ('medium', 10, ?)",
+  );
+  const entry = t.sqlite.prepare(
+    `INSERT INTO completed_exercises
+       (sessionId, exerciseId, roundIndex, sortOrder, resultType, resultValue, targetType,
+        targetValue, performedAt)
+     VALUES (?, ?, 0, ?, 'reps', 10, 'reps', 10, ?)`,
+  );
+
+  // `isEarned` wants PROGRESSION_SESSIONS_REQUIRED distinct on-target sessions.
+  for (let n = 0; n < 3; n++) {
+    const sessionId = Number(session.run(at - n * 86400).lastInsertRowid);
+    ids.forEach((row, i) => {
+      entry.run(sessionId, row.id, i, at - n * 86400);
+    });
+  }
+}
+
 export function createTestDb() {
   const sqlite = new Database(":memory:");
 

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react-native";
 import { WARMUP_SEQUENCE } from "@/constants/warmup";
+import type { Exercise } from "@/db/exercises";
 import { preferences } from "@/db/preferences";
 import type { Quest } from "@/db/quests";
 import { useSessionStore } from "../stores/session";
@@ -805,6 +806,88 @@ describe("useSessionStore", () => {
 
       expect(store.getState().status).toBe("running");
       expect(store.getState().results).toHaveLength(0);
+    });
+  });
+
+  describe("changing the movement mid-session", () => {
+    const easier = {
+      id: 99,
+      enName: "Wall Push-Up",
+      frName: "Pompe au mur",
+      difficulty: "easy",
+      secondsPerRep: 2,
+      muscles: ["chest"],
+    } as unknown as Exercise;
+
+    beforeEach(() => {
+      store.setState({
+        quest: mockQuest as unknown as Quest,
+        status: "running",
+        currentRoundIndex: 0,
+        currentExerciseIndex: 0,
+        results: [],
+        startTime: Date.now(),
+      });
+    });
+
+    test("replaces the movement ahead and drops the art that belonged to the old one", () => {
+      store.getState().swapCurrentExercise(easier);
+
+      const slot = store.getState().quest?.exercises[0];
+      expect(slot?.exercise.enName).toBe("Wall Push-Up");
+      expect(slot?.images).toEqual([]);
+    });
+
+    test("leaves results already logged exactly as they were", () => {
+      store.getState().completeExercise(10);
+      const before = store.getState().results;
+
+      store.setState({ currentExerciseIndex: 0, status: "running" });
+      store.getState().swapCurrentExercise(easier);
+
+      expect(store.getState().results).toEqual(before);
+      expect(store.getState().results[0]?.exerciseId).toBe(before[0]?.exerciseId);
+    });
+
+    /**
+     * The trap this whole field exists for. `toXpSets` used to re-read the movement off the slot
+     * at save time, so swapping to a harder one on the last round re-priced every set already
+     * logged. Two sets, a swap, and the first two must still cost what they cost.
+     */
+    test("does not re-price the sets already done", () => {
+      store.getState().completeExercise(10);
+
+      const pricedAtCompletion = store.getState().results[0]?.pricing;
+      expect(pricedAtCompletion).toEqual({
+        secondsPerRep: (mockQuest as unknown as Quest).exercises[0]?.exercise.secondsPerRep,
+        difficulty: (mockQuest as unknown as Quest).exercises[0]?.exercise.difficulty,
+      });
+
+      store.setState({ currentExerciseIndex: 0, status: "running" });
+      store.getState().swapCurrentExercise(easier);
+
+      // The slot changed; the set's own price did not.
+      expect(store.getState().quest?.exercises[0]?.exercise.difficulty).toBe("easy");
+      expect(store.getState().results[0]?.pricing).toEqual(pricedAtCompletion);
+    });
+
+    test("resets the timer to the unit the new movement is measured in", () => {
+      store.setState({ timerStartTimestamp: 123, timerDuration: 45 });
+
+      store.getState().swapCurrentExercise(easier);
+
+      // mockQuest's first slot is rep-based, so a hold timer must not be left running on it.
+      const isTimeBased = (mockQuest as unknown as Quest).exercises[0]?.target.type === "time";
+      expect(store.getState().timerStartTimestamp === null).toBe(!isTimeBased);
+    });
+
+    test("swapping to the movement already there is a no-op", () => {
+      const same = (mockQuest as unknown as Quest).exercises[0]?.exercise;
+      const before = store.getState().quest;
+
+      store.getState().swapCurrentExercise(same as never);
+
+      expect(store.getState().quest).toBe(before);
     });
   });
 });

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -733,4 +733,78 @@ describe("useSessionStore", () => {
       expect(store.getState().bossFight?.currentHp).toBeGreaterThan(0);
     });
   });
+
+  /**
+   * Issue #33's second half. `CHECK (resultValue > 0)` made "1" the only way past a movement out
+   * of reach, and that 1 then fed muscle volume, the weak-area read and the targets generated
+   * from them — the app teaching its own journal a lie.
+   */
+  describe("a set the hero could not do", () => {
+    beforeEach(() => {
+      store.setState({
+        quest: mockQuest as unknown as Quest,
+        status: "running",
+        currentRoundIndex: 0,
+        currentExerciseIndex: 0,
+        results: [],
+        lastSetSkipped: false,
+        startTime: Date.now(),
+      });
+    });
+
+    test("writes no result at all, rather than a 1", () => {
+      store.getState().completeExercise(10);
+      store.getState().skipExercise();
+
+      const { results } = store.getState();
+      expect(results).toHaveLength(1);
+      expect(results[0]?.sortOrder).toBe(0);
+      expect(store.getState().lastSetSkipped).toBe(true);
+    });
+
+    test("advances exactly like a completed set would", () => {
+      store.getState().skipExercise();
+
+      // Same landing as `completeExercise`: the second slot, with the rest screen in between.
+      expect(store.getState().currentExerciseIndex).toBe(1);
+      expect(store.getState().status).toBe("resting");
+    });
+
+    test("banks no boss damage", () => {
+      store.setState({
+        bossFight: { id: 1, totalHp: 100, currentHp: 100, defeatedAt: null } as never,
+        pendingDamage: [],
+      });
+
+      store.getState().skipExercise();
+
+      expect(store.getState().pendingDamage).toHaveLength(0);
+      expect(store.getState().bossFight?.currentHp).toBe(100);
+    });
+
+    test("completing a set afterwards clears the flag the rest screen reads", () => {
+      store.getState().skipExercise();
+      expect(store.getState().lastSetSkipped).toBe(true);
+
+      store.getState().completeExercise(8);
+      expect(store.getState().lastSetSkipped).toBe(false);
+    });
+
+    /**
+     * A session with nothing in it cannot be written, and the victory screen would sit on a retry
+     * that can never succeed. Quit is the way out of a workout the hero cannot do.
+     */
+    test("the last remaining set is not skippable on an empty journal", () => {
+      store.setState({
+        currentRoundIndex: (mockQuest as unknown as Quest).rounds - 1,
+        currentExerciseIndex: (mockQuest as unknown as Quest).exercises.length - 1,
+        results: [],
+      });
+
+      store.getState().skipExercise();
+
+      expect(store.getState().status).toBe("running");
+      expect(store.getState().results).toHaveLength(0);
+    });
+  });
 });

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -2,6 +2,7 @@ import { waitFor } from "@testing-library/react-native";
 import { WARMUP_SEQUENCE } from "@/constants/warmup";
 import type { Exercise } from "@/db/exercises";
 import { preferences } from "@/db/preferences";
+import { saveQuestConfig } from "@/db/questConfig";
 import type { Quest } from "@/db/quests";
 import { useSessionStore } from "../stores/session";
 
@@ -39,6 +40,10 @@ jest.mock("@/db/exercises", () => ({
 jest.mock("@/db/oaths", () => ({
   checkOathFulfilled: jest.fn().mockResolvedValue(null),
   OATH_XP_BONUS: 50,
+}));
+jest.mock("@/db/questConfig", () => ({
+  ...jest.requireActual("@/db/questConfig"),
+  saveQuestConfig: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock("@/db/queryCache", () => ({
   ...jest.requireActual("@/db/queryCache"),
@@ -879,6 +884,19 @@ describe("useSessionStore", () => {
       // mockQuest's first slot is rep-based, so a hold timer must not be left running on it.
       const isTimeBased = (mockQuest as unknown as Quest).exercises[0]?.target.type === "time";
       expect(store.getState().timerStartTimestamp === null).toBe(!isTimeBased);
+    });
+
+    /**
+     * The sheet on the quest screen writes `quest:<id>:config`; this one deliberately does not.
+     * That is configuration, posted cold before starting; this is a correction for tonight, made
+     * mid-set on a movement that turned out to be out of reach. Persisting it pins the slot —
+     * `applyQuestConfig` swaps before `currentRungFor` runs — and the progression substitution
+     * issue #33 exists for would stop applying to the one slot the hero struggled on.
+     */
+    test("does not pin the slot in the quest's saved config", () => {
+      store.getState().swapCurrentExercise(easier);
+
+      expect(saveQuestConfig).not.toHaveBeenCalled();
     });
 
     test("swapping to the movement already there is a no-op", () => {

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -13,6 +13,7 @@ jest.mock("@/db/client", () => ({
 
 // Mock quests module
 jest.mock("@/db/quests", () => ({
+  ...jest.requireActual("@/db/quests"),
   isDailyQuest: jest.fn().mockReturnValue(false),
 }));
 
@@ -39,6 +40,7 @@ jest.mock("@/db/oaths", () => ({
   OATH_XP_BONUS: 50,
 }));
 jest.mock("@/db/queryCache", () => ({
+  ...jest.requireActual("@/db/queryCache"),
   clearShortLivedQueries: jest.fn(),
 }));
 jest.mock("@/db/userLevel", () => ({
@@ -53,11 +55,13 @@ jest.mock("@/db/village", () => ({
 jest.mock("@/src/widget", () => ({
   requestWidgetsUpdate: jest.fn().mockResolvedValue(undefined),
 }));
+// Spread the real module, stub only the one function these tests want deterministic. A flat mock
+// listing constants by hand made every symbol added to `db/xp.ts` arrive `undefined` with no error
+// anywhere — `Math.min(undefined, xp)` is NaN, and the failure surfaces three asserts later.
+// Same idiom as `@/db/bossFights` above.
 jest.mock("@/db/xp", () => ({
+  ...jest.requireActual("@/db/xp"),
   computeSessionXp: jest.fn().mockReturnValue(100),
-  // Real value, not a stand-in: `saveSession` clamps with it, and a mock that omits it turns the
-  // session's XP into NaN with no error anywhere.
-  MAX_SESSION_XP: 2000,
 }));
 jest.mock("@/db/preferences", () => ({
   preferences: {

--- a/app/(tabs)/quests/[id].tsx
+++ b/app/(tabs)/quests/[id].tsx
@@ -42,7 +42,7 @@ import { getCached } from "@/db/queryCache";
 import type { Quest } from "@/db/quests";
 import type { DifficultyCode, EquipmentCode } from "@/db/schema";
 import { formatTarget } from "@/db/targets";
-import { localizedTitle } from "@/src/i18n/localized";
+import { localizedName, localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useSessionStore } from "@/stores/session";
 import { useSettingsStore } from "@/stores/settings";
@@ -682,6 +682,18 @@ export default function QuestDetails() {
                             tone={qex.target.type === "time" ? "secondary" : "primary"}
                           />
                         </XStack>
+
+                        {/* A slot the hero is not on the rung for is served easier (issue #33).
+                          Said out loud, or the card disagrees with the quest for no visible
+                          reason — and the movement it names stays one tap away through swap. */}
+                        {qex.substitutedFor ? (
+                          <Text fontSize={12} color="$textSecondary" fontFamily="$body">
+                            {t("quests.served_easier_rung", {
+                              name: localizedName(qex.substitutedFor, language),
+                              defaultValue: `Working up to ${localizedName(qex.substitutedFor, language)}`,
+                            })}
+                          </Text>
+                        ) : null}
 
                         {thumbs.length > 0 ? (
                           <XStack gap="$2" pt="$2" pb="$1">

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -274,6 +274,18 @@ export function ActiveExerciseView() {
             {/* The exercise's name is on the artwork either way now — the hero paints it, and in a
               fight the arena carries it on its own scrim. Nothing repeats it here. */}
             <YStack items="center" gap="$2" width="100%">
+              {/* The template named a harder movement and the hero is not on that rung yet
+                (issue #33). Named here too: mid-session is where the substitution is felt, and
+                a hero who thinks the app got it wrong is a hero who logs a lie. */}
+              {currentEx.substitutedFor ? (
+                <Text fontSize={12} color="$textSecondary" fontFamily="$body" text="center">
+                  {t("quests.served_easier_rung", {
+                    name: localizedName(currentEx.substitutedFor, language),
+                    defaultValue: `Working up to ${localizedName(currentEx.substitutedFor, language)}`,
+                  })}
+                </Text>
+              ) : null}
+
               {/* How to do it - expandable */}
               {exerciseDescription ? (
                 <YStack width="100%">

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -38,6 +38,7 @@ export function ActiveExerciseView() {
   const currentRoundIndex = useSessionStore((s) => s.currentRoundIndex);
   const currentExerciseIndex = useSessionStore((s) => s.currentExerciseIndex);
   const completeExercise = useSessionStore((s) => s.completeExercise);
+  const skipExercise = useSessionStore((s) => s.skipExercise);
   const pauseSession = useSessionStore((s) => s.pauseSession);
   const bossFight = useSessionStore((s) => s.bossFight);
   const lastDamageResult = useSessionStore((s) => s.lastDamageResult);
@@ -82,6 +83,11 @@ export function ActiveExerciseView() {
     } else {
       completeExercise(Math.max(1, adjustedReps));
     }
+  };
+
+  const handleSkip = () => {
+    selection();
+    skipExercise();
   };
 
   const handleAdjustReps = (delta: number) => {
@@ -471,6 +477,23 @@ export function ActiveExerciseView() {
             ) : null}
           </YStack>
         </ScrollView>
+
+        {/* The honest way out of a movement the hero cannot do. Deliberately quiet next to the
+          primary action — it is a release valve, not a choice being offered. Before it existed,
+          `CHECK (resultValue > 0)` made "1" the only way past, and that 1 went on to feed muscle
+          volume, the weak-area read and every target generated from them (issue #33). */}
+        <Pressable
+          testID="session-skip-exercise"
+          onPress={handleSkip}
+          accessibilityRole="button"
+          accessibilityLabel={t("session.skip_exercise")}
+        >
+          <XStack items="center" justify="center" py="$2" opacity={0.7} hoverStyle={{ opacity: 1 }}>
+            <Text fontSize={13} fontWeight="700" color="$textSecondary" fontFamily="$body">
+              {t("session.skip_exercise")}
+            </Text>
+          </XStack>
+        </Pressable>
 
         {/* Footer Action */}
         <Button

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -1,23 +1,28 @@
 import { ChevronDown, ChevronUp, Crosshair, Pause } from "@tamagui/lucide-icons";
 import { Image } from "expo-image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, H1, Paragraph, Progress, Text, XStack, YStack } from "tamagui";
 import { GameIcon } from "@/components/common/GameIcon";
+import { ExercisePickerSheet } from "@/components/quests/ExercisePickerSheet";
 import { getExerciseAsset, getExerciseThumb } from "@/constants/assetMap";
 import { bossDisplayName } from "@/constants/bosses";
 import {
   getExerciseBgForSessionStep,
   getExerciseBgRawForSessionStep,
 } from "@/constants/exerciseColors";
+import { rankSwapCandidates, type SwapReason } from "@/constants/exerciseFilters";
 import { critChance } from "@/db/bossFights";
+import { type Exercise, listExercises, pickableExercises } from "@/db/exercises";
+import { preferences } from "@/db/preferences";
 import { formatTarget } from "@/db/targets";
 import { useHaptics } from "@/hooks/useHaptics";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 import { formatOvertime, formatTime, useSessionTimer } from "@/hooks/useSessionTimer";
 import { localizedName } from "@/src/i18n/localized";
+import { reportError } from "@/src/reportError";
 import { useSessionStore } from "@/stores/session";
 import { useSettingsStore } from "@/stores/settings";
 import { BossArena } from "./BossArena";
@@ -39,6 +44,28 @@ export function ActiveExerciseView() {
   const currentExerciseIndex = useSessionStore((s) => s.currentExerciseIndex);
   const completeExercise = useSessionStore((s) => s.completeExercise);
   const skipExercise = useSessionStore((s) => s.skipExercise);
+  const swapCurrentExercise = useSessionStore((s) => s.swapCurrentExercise);
+
+  // Loaded when the session screen mounts, not when the sheet opens: the moment a hero reaches
+  // for this is the moment they are stuck, and a spinner there is the worst possible time.
+  // `listExercises()` is promise-cached, so this is free after the first read anywhere in the app.
+  const [catalogue, setCatalogue] = useState<Exercise[]>([]);
+  const [owned, setOwned] = useState<ReadonlySet<string> | null>(null);
+  const [swapOpen, setSwapOpen] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    Promise.all([listExercises(), preferences.getOwnedEquipment()])
+      .then(([all, equipment]) => {
+        if (!alive) return;
+        setCatalogue(all);
+        setOwned(equipment === null ? null : new Set(equipment));
+      })
+      .catch((e) => reportError("session.catalogue", e));
+    return () => {
+      alive = false;
+    };
+  }, []);
   const pauseSession = useSessionStore((s) => s.pauseSession);
   const bossFight = useSessionStore((s) => s.bossFight);
   const lastDamageResult = useSessionStore((s) => s.lastDamageResult);
@@ -88,6 +115,22 @@ export function ActiveExerciseView() {
   const handleSkip = () => {
     selection();
     skipExercise();
+  };
+
+  // Ladder rungs first, then the same pattern, then the family — `rankSwapCandidates` already
+  // encodes that order for the quest screen, and a hero stuck mid-set wants the easier rung at
+  // the top of the list.
+  const swapCandidates = swapOpen
+    ? rankSwapCandidates(pickableExercises(catalogue), currentEx.exercise, owned as never)
+    : [];
+  const swapReasons = new Map(swapCandidates.map((c) => [c.exercise.id, c.reason] as const));
+
+  const swapReasonLabel = (reason: SwapReason | null | undefined): string | null => {
+    if (reason === "easier") return t("quests.swap_reason_easier", "An easier rung");
+    if (reason === "harder") return t("quests.swap_reason_harder", "A harder rung");
+    if (reason === "same_pattern") return t("quests.swap_reason_pattern", "Same movement");
+    if (reason === "same_family") return t("quests.swap_reason_family", "Same family");
+    return null;
   };
 
   const handleAdjustReps = (delta: number) => {
@@ -478,6 +521,24 @@ export function ActiveExerciseView() {
           </YStack>
         </ScrollView>
 
+        {/* Out of reach is not always "I cannot" — often it is "not this variation". The sheet
+          the quest screen has always had, reachable at the moment it is actually needed. */}
+        <Pressable
+          testID="session-swap-exercise"
+          onPress={() => {
+            selection();
+            setSwapOpen(true);
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={t("quests.swap_exercise")}
+        >
+          <XStack items="center" justify="center" py="$2" opacity={0.7} hoverStyle={{ opacity: 1 }}>
+            <Text fontSize={13} fontWeight="700" color="$textSecondary" fontFamily="$body">
+              {t("quests.swap_exercise")}
+            </Text>
+          </XStack>
+        </Pressable>
+
         {/* The honest way out of a movement the hero cannot do. Deliberately quiet next to the
           primary action — it is a release valve, not a choice being offered. Before it existed,
           `CHECK (resultValue > 0)` made "1" the only way past, and that 1 went on to feed muscle
@@ -516,6 +577,22 @@ export function ActiveExerciseView() {
           </Text>
         </Button>
       </YStack>
+
+      <ExercisePickerSheet
+        exercises={swapCandidates.map((c) => c.exercise)}
+        pickedIds={[currentEx.exercise.id]}
+        language={language}
+        open={swapOpen}
+        onOpenChange={setSwapOpen}
+        title={t("quests.swap_exercise", "Replace this movement")}
+        onPick={(exercise) => {
+          swapCurrentExercise(exercise);
+          setSwapOpen(false);
+        }}
+        captionFor={(exercise) => swapReasonLabel(swapReasons.get(exercise.id))}
+        bottomInset={insets.bottom}
+        pickAction={null}
+      />
     </YStack>
   );
 }

--- a/components/session/RestView.tsx
+++ b/components/session/RestView.tsx
@@ -33,6 +33,7 @@ export function RestView() {
   const addRestTime = useSessionStore((s) => s.addRestTime);
   const results = useSessionStore((s) => s.results);
   const updateLastResult = useSessionStore((s) => s.updateLastResult);
+  const lastSetSkipped = useSessionStore((s) => s.lastSetSkipped);
   const bossFight = useSessionStore((s) => s.bossFight);
   const lastDamageResult = useSessionStore((s) => s.lastDamageResult);
   const status = useSessionStore((s) => s.status);
@@ -212,8 +213,10 @@ export function RestView() {
             </XStack>
           </YStack>
 
-          {/* Last Set Review */}
-          {!!lastResult && (
+          {/* Last Set Review — hidden after a skip. A skipped set writes no result, so
+            `results.at(-1)` is a set from an earlier round: the stepper would silently correct
+            something the hero is not looking at. */}
+          {!!lastResult && !lastSetSkipped && (
             <YStack
               bg="$surface"
               p="$4"

--- a/db/completed.ts
+++ b/db/completed.ts
@@ -35,6 +35,17 @@ export type CompletedExerciseInput = {
 
   notes?: string;
   performedAt?: Date;
+
+  /**
+   * What this set cost, captured when it was done. In memory only — there is no column, and
+   * `createCompletedSession` ignores it.
+   *
+   * XP prices a set by the movement's tempo and difficulty, and `toXpSets` used to re-read those
+   * off the quest slot at save time. That is fine until a slot can change mid-session: swapping to
+   * a `hard` movement on the last round would re-price every set already logged, inflating the
+   * whole workout. The price belongs to the moment, like `target` beside it.
+   */
+  pricing?: { secondsPerRep: number; difficulty: DifficultyCode };
 };
 
 export type CompletedSessionInput = {

--- a/db/exercises.ts
+++ b/db/exercises.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gte, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { db, schema } from "./client";
 import { isEquipmentCode } from "./equipment";
 import { isMuscleCode } from "./muscles";
@@ -214,7 +214,7 @@ export const PROGRESSION_SESSIONS_REQUIRED = 3;
 /** How many recent rows to scan when looking for the most recently trained movements. */
 const RECENT_RESULT_ROWS = 60;
 
-type MovementRef = { id: number; enName: string; frName: string; imagePath: string };
+export type MovementRef = { id: number; enName: string; frName: string; imagePath: string };
 
 /** One rung of the ladder, seen from below: the movement, and how close its next step is. */
 export type VariationStep = {
@@ -435,6 +435,108 @@ async function allSessionMetFlags(): Promise<Map<number, boolean[]>> {
     byExercise.set(row.exerciseId, flags);
   }
   return byExercise;
+}
+
+/**
+ * `recentMetFlags` for many movements at once — the *current* state, windowed, most recent first.
+ *
+ * `allSessionMetFlags` above answers a different question (did it *ever* happen, unwindowed, for
+ * the trophy shelf) and cannot stand in: a hero who owned a rung last spring is not standing on it
+ * tonight. This is the same seek `recentMetFlags` does, hoisted out of the per-movement loop
+ * because `currentRungFor` needs it for every rung of every slot of a quest.
+ */
+async function recentMetFlagsBatch(exerciseIds: number[]): Promise<Map<number, boolean[]>> {
+  if (exerciseIds.length === 0) return new Map();
+
+  const since = new Date(Date.now() - PROGRESSION_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const met = sql<number>`min(case when ${schema.completedExercises.targetValue} is not null
+      and ${schema.completedExercises.resultValue} >= ${schema.completedExercises.targetValue}
+    then 1 else 0 end)`;
+  const at = sql<number>`max(${schema.completedExercises.performedAt})`;
+
+  const rows = await db
+    .select({ exerciseId: schema.completedExercises.exerciseId, met })
+    .from(schema.completedExercises)
+    .where(
+      and(
+        inArray(schema.completedExercises.exerciseId, exerciseIds),
+        gte(schema.completedExercises.performedAt, since),
+      ),
+    )
+    .groupBy(schema.completedExercises.exerciseId, schema.completedExercises.sessionId)
+    .orderBy(
+      schema.completedExercises.exerciseId,
+      desc(at),
+      desc(schema.completedExercises.sessionId),
+    );
+
+  const byExercise = new Map<number, boolean[]>();
+  for (const row of rows) {
+    const flags = byExercise.get(row.exerciseId) ?? [];
+    // Most recent first, and only as many as a rung is judged on — the `limit` of the
+    // per-movement query, applied here because one query serves every movement.
+    if (flags.length < PROGRESSION_SESSIONS_REQUIRED) {
+      flags.push(row.met === 1);
+      byExercise.set(row.exerciseId, flags);
+    }
+  }
+  return byExercise;
+}
+
+/**
+ * For each movement asked about, the one the hero is actually working: the lowest rung of its
+ * chain they have not yet earned, or the movement itself once everything below it is owned.
+ *
+ * This is what stops a quest handing classical push-ups to someone whose last session was wall
+ * push-ups (issue #33). It reads the same `isEarned` rule the exercise screen shows, so the app
+ * never prescribes something it is simultaneously telling the hero to work up to.
+ *
+ * Batched rather than `getChainTo` per slot: that walks the whole `exercises` table and seeks the
+ * journal once per rung, and this runs for every slot of every quest Home resolves.
+ *
+ * A movement off the ladder, or one whose chain is fully earned, maps to itself — callers can
+ * treat the result as a total function and never special-case.
+ */
+export async function currentRungFor(exerciseIds: number[]): Promise<Map<number, number>> {
+  const wanted = [...new Set(exerciseIds)];
+  if (wanted.length === 0) return new Map();
+
+  const rows = await fetchLadderRows();
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  // Walk each request down to its easiest variation first, so one journal read covers every rung
+  // of every chain involved.
+  const chains = new Map<number, number[]>();
+  for (const id of wanted) {
+    const chain: number[] = [];
+    const seen = new Set<number>();
+    let cursor = byId.get(id);
+    // `seen` guards a cycle in the data, which would otherwise hang rather than fail.
+    while (cursor && !seen.has(cursor.id)) {
+      seen.add(cursor.id);
+      chain.unshift(cursor.id);
+      cursor = cursor.prerequisiteExerciseId ? byId.get(cursor.prerequisiteExerciseId) : undefined;
+    }
+    chains.set(id, chain);
+  }
+
+  const flags = await recentMetFlagsBatch([...new Set([...chains.values()].flat())]);
+  const earned = (exerciseId: number): boolean =>
+    (flags.get(exerciseId) ?? []).filter(Boolean).length >= PROGRESSION_SESSIONS_REQUIRED;
+
+  const result = new Map<number, number>();
+  for (const id of wanted) {
+    const chain = chains.get(id) ?? [];
+    // Contiguous from the bottom, exactly as `getChainTo` counts: owning a hard variation out of
+    // order does not skip the ones below it.
+    let climbed = 0;
+    while (climbed < chain.length && earned(chain[climbed] as number)) climbed++;
+
+    // `chain[climbed]` is the first unearned rung; past the top it is undefined, which means
+    // everything is owned and the movement as written is the right one.
+    result.set(id, chain[climbed] ?? id);
+  }
+  return result;
 }
 
 /** Whether a run of `PROGRESSION_SESSIONS_REQUIRED` on-target sessions ever happened. */

--- a/db/questConfig.ts
+++ b/db/questConfig.ts
@@ -234,6 +234,10 @@ export function applyQuestConfig(
               // The ghost belongs to the slot's old movement too, and the substitute's own
               // history is not in this object — better silent than wrong.
               ghost: undefined,
+              // An explicit swap outranks the rung substitution `getQuestById` may have made, so
+              // the "we served you an easier rung" caption has to go with it. Left behind, the
+              // screen would explain a substitution that is no longer on the slot.
+              substitutedFor: undefined,
             }),
       };
     }),

--- a/db/quests.ts
+++ b/db/quests.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq } from "drizzle-orm";
 import { db, schema } from "./client";
 import { dayKey } from "./dates";
-import type { Exercise } from "./exercises";
+import { currentRungFor, type Exercise, listExercises, type MovementRef } from "./exercises";
 import { isMuscleCode } from "./muscles";
 import { type ExerciseGhost, getExerciseHistory, ghostKey } from "./personalRecords";
 import { preferences, type TrainingLevel } from "./preferences";
@@ -11,6 +11,9 @@ import {
   ADMIN_CREATOR,
   type ContentOwner,
   type DifficultyCode,
+  type EquipmentCode,
+  type ExerciseStyle,
+  type MovementPattern,
   type MuscleCode,
   type QuestArchetype,
   type QuestTargetType,
@@ -38,6 +41,16 @@ export interface QuestExercise {
 
   /** Target for this quest – either repetitions or seconds */
   target: Target;
+
+  /**
+   * The movement the quest template actually names, when the hero is served an easier rung of its
+   * chain instead. Absent on every slot that runs as written.
+   *
+   * Issue #33: a quest that hands classical push-ups to someone whose last session was wall
+   * push-ups is a wall, not a stretch. The substitution is silent without this — and a quest that
+   * quietly shows something other than its own card reads as a bug from where the hero sits.
+   */
+  substitutedFor?: MovementRef;
 
   /**
    * What the hero has already done on this movement, in *this slot's* unit — the best set of
@@ -395,6 +408,90 @@ export async function getQuestTemplateById(id: number): Promise<QuestTemplate | 
   return quest;
 }
 
+type SlotRow = {
+  qexId: number;
+  targetType: QuestTargetType;
+  targetMin: number;
+  targetMax: number;
+  imagesJson: string;
+  exId: number;
+  exEnName: string;
+  exFrName: string;
+  exEnDescription: string;
+  exFrDescription: string;
+  exImagePath: string;
+  exCreator: ContentOwner;
+  exDifficulty: DifficultyCode;
+  exEquipment: EquipmentCode;
+  exStyle: ExerciseStyle | null;
+  exSecondsPerRep: number;
+  exPattern: MovementPattern | null;
+  exPrerequisiteId: number | null;
+  exRetiredAt: Date | null;
+};
+
+/**
+ * One slot of a quest, resolved for this hero.
+ *
+ * Split out of `getQuestById` so the substitution (issue #33) does not push one function past
+ * what anyone can hold in their head — the loop that calls this only has to know that a row
+ * either opens a slot or adds a muscle to one.
+ */
+function buildSlot(
+  r: SlotRow,
+  ctx: {
+    userLevel: UserLevel;
+    servedId: (exerciseId: number) => number;
+    catalogue: Map<number, Exercise>;
+    history: Map<string, ExerciseGhost>;
+  },
+): QuestExercise {
+  const base = { type: r.targetType, min: r.targetMin, max: r.targetMax };
+
+  // The movement this slot will actually run. Identical to the written one unless the hero is
+  // still working a rung below it — and never for a quest they authored themselves.
+  const served = ctx.catalogue.get(ctx.servedId(r.exId));
+  const isSubstituted = served !== undefined && served.id !== r.exId;
+  const effectiveId = ctx.servedId(r.exId);
+
+  return {
+    id: r.qexId,
+    exercise: served ?? {
+      id: r.exId,
+      enName: r.exEnName,
+      frName: r.exFrName,
+      enDescription: r.exEnDescription,
+      frDescription: r.exFrDescription,
+      imagePath: r.exImagePath,
+      creator: r.exCreator,
+      difficulty: r.exDifficulty,
+      equipment: r.exEquipment,
+      style: r.exStyle ?? "strength",
+      secondsPerRep: r.exSecondsPerRep,
+      pattern: r.exPattern ?? null,
+      prerequisiteExerciseId: r.exPrerequisiteId,
+      retiredAt: r.exRetiredAt,
+      muscles: [],
+    },
+    // The quest's own art is *of the movement the template wrote*; on a substituted slot it
+    // would illustrate the wrong exercise. Same call `applyQuestConfig` makes on a swap.
+    images: isSubstituted ? [] : safeParseImages(r.imagesJson),
+    target: generateTarget(
+      base,
+      ctx.userLevel,
+      ctx.history.get(ghostKey(effectiveId, "time"))?.best,
+    ),
+    // In the slot's own unit: a movement trained both ways has two records, and showing the
+    // hold next to a rep target would be a number the hero cannot act on.
+    ghost: ctx.history.get(ghostKey(effectiveId, r.targetType)),
+    // What the template asked for, when that is not what runs — the screens owe the hero an
+    // explanation and a way back, and nothing else in the object can tell them.
+    substitutedFor: isSubstituted
+      ? { id: r.exId, enName: r.exEnName, frName: r.exFrName, imagePath: r.exImagePath }
+      : undefined,
+  };
+}
+
 export async function getQuestById(id: number, userLevel: UserLevel): Promise<Quest | null> {
   // Join quests -> quest_exercises -> exercises -> exercise_muscles and aggregate.
   const rows = await db
@@ -445,11 +542,32 @@ export async function getQuestById(id: number, userLevel: UserLevel): Promise<Qu
   const first = rows[0];
   if (!first) return null;
 
+  // What the hero is actually working, per slot — a quest that names classical push-ups serves
+  // wall push-ups to someone who has not earned the rungs below (issue #33). Resolved before the
+  // journal read below, because a substituted slot must be priced and ghosted against the movement
+  // it will actually run, not the one the template wrote.
+  //
+  // Hero-authored quests are left exactly as written: substituting there would be correcting
+  // someone's own authoring, which is not this function's business.
+  const substitutes = isUserQuest(first)
+    ? new Map<number, number>()
+    : await currentRungFor(rows.map((r) => r.exId));
+  const servedId = (exerciseId: number): number => substitutes.get(exerciseId) ?? exerciseId;
+
   // Two things come out of the journal here, in one grouped query: the longest hold, because a
   // hold is prescribed from the hero's own maximum (60-75% of it), and the ghost every slot shows
   // — what they did last time on this movement. Both are per (movement, unit), so one read
   // answers both and nothing is fetched again mid-session.
-  const history = await getExerciseHistory([...new Set(rows.map((r) => r.exId))]);
+  const history = await getExerciseHistory([
+    ...new Set(rows.flatMap((r) => [r.exId, servedId(r.exId)])),
+  ]);
+
+  // A substituted slot needs the whole movement, not the four fields the ladder carries: the
+  // session prices it by `difficulty` and `secondsPerRep`, and the village counts its muscles.
+  // `listExercises()` is promise-cached, so this is free after the first read anywhere.
+  const catalogue = new Map<number, Exercise>(
+    substitutes.size > 0 ? (await listExercises()).map((e) => [e.id, e]) : [],
+  );
 
   const quest: Quest = {
     id: first.questId,
@@ -469,47 +587,24 @@ export async function getQuestById(id: number, userLevel: UserLevel): Promise<Qu
   const byQuestExercise = new Map<number, QuestExercise>();
 
   for (const r of rows) {
-    const base = {
-      type: r.targetType,
-      min: r.targetMin,
-      max: r.targetMax,
-    };
-
     let qex = byQuestExercise.get(r.qexId);
     if (!qex) {
-      qex = {
-        id: r.qexId,
-        exercise: {
-          id: r.exId,
-          enName: r.exEnName,
-          frName: r.exFrName,
-          enDescription: r.exEnDescription,
-          frDescription: r.exFrDescription,
-          imagePath: r.exImagePath,
-          creator: r.exCreator,
-          difficulty: r.exDifficulty,
-          equipment: r.exEquipment,
-          style: r.exStyle ?? "strength",
-          secondsPerRep: r.exSecondsPerRep,
-          pattern: r.exPattern ?? null,
-          prerequisiteExerciseId: r.exPrerequisiteId,
-          retiredAt: r.exRetiredAt,
-          muscles: [],
-        },
-        images: safeParseImages(r.imagesJson),
-        target: generateTarget(base, userLevel, history.get(ghostKey(r.exId, "time"))?.best),
-        // In the slot's own unit: a movement trained both ways has two records, and showing the
-        // hold next to a rep target would be a number the hero cannot act on.
-        ghost: history.get(ghostKey(r.exId, r.targetType)),
-      };
+      qex = buildSlot(r, { userLevel, servedId, catalogue, history });
       byQuestExercise.set(r.qexId, qex);
       quest.exercises.push(qex);
     }
 
-    if (isMuscleCode(r.muscle) && !qex.exercise.muscles.includes(r.muscle)) {
+    // The join carries the *written* movement's muscles; a substituted slot already arrived with
+    // its own from the catalogue and must not collect the other one's.
+    if (
+      qex.exercise.id === r.exId &&
+      isMuscleCode(r.muscle) &&
+      !qex.exercise.muscles.includes(r.muscle)
+    ) {
       qex.exercise.muscles.push(r.muscle);
     }
   }
+
   setCached(`quest:${id}:${userLevel}`, quest);
   return quest;
 }

--- a/docs/gameplay/paths.md
+++ b/docs/gameplay/paths.md
@@ -80,6 +80,13 @@ The path also answers the *downward* question. The rung the hero stands on is th
 "this is too hard, what do I train instead?" — and it is not the direct prerequisite, which on the
 Pull-ups page would be Chin-Up.
 
+Since [issue #33](https://github.com/Guiforge/bati/issues/33) a quest *answers that question by
+itself*: a slot naming a movement whose lower rungs are unearned runs at the rung the hero is on.
+That is still not a gate, and the distinction is the whole point — the written movement is named
+on the card ("Working up to Push-ups") and is one tap away in the swap sheet. What changed is the
+default, not the permission. A hero who wants the summit tonight still gets it by asking; before,
+the only way to decline was to type a number they had not performed.
+
 ## Where a path speaks
 
 | Surface | What it says |

--- a/docs/gameplay/quests.md
+++ b/docs/gameplay/quests.md
@@ -64,9 +64,34 @@ Each quest contains an ordered list of exercises:
 
 | Difficulty | Target Adjustment | XP Multiplier |
 | ---------- | ----------------- | ------------- |
-| **Easy** | Use targetMin | 0.8x |
-| **Medium** | Average of min/max | 1.0x |
-| **Hard** | Use targetMax | 1.2x |
+| **Easy** | Targets x0.75 | 0.9x |
+| **Medium** | Targets x1.0 | 1.0x |
+| **Hard** | Targets x1.25 | 1.2x |
+
+Difficulty moves the *numbers*. It never changes the *movement* — which is why it is not, on its
+own, an answer to "this is beyond me". That is the section below.
+
+### The slot serves the rung the hero is on
+
+A quest names a movement; `getQuestById` serves the one the hero is actually working. If the
+ladder (`prerequisiteExerciseId`) puts Wall Push-Up under Knee Push-Up under Push-ups, and the
+hero has not yet earned the rungs below, the push-up slot runs as Wall Push-Up. The slot carries
+`substitutedFor` so both the quest card and the session screen can say "Working up to Push-ups",
+and the swap sheet is one tap away for anyone who wants the written movement anyway.
+
+Ownership is the same `isEarned` rule the exercise screen shows — three on-target sessions inside
+the 56-day window — so the app never prescribes something it is simultaneously telling the hero to
+work up to.
+
+Four things it never does: override an explicit swap, touch a quest the hero authored themselves,
+substitute upward, or carry the quest's own artwork onto a movement it does not depict.
+
+**Why it exists.** [Issue #33](https://github.com/Guiforge/bati/issues/33): a beginner did wall
+push-ups on day one and was handed classical push-ups on day two. The only way past was to type
+"1" — the lowest the field accepts — which then fed muscle volume, the weak-area read and every
+target generated from them. The app had the ladder recorded the whole time; it just was not
+reading it when it mattered. A session can now also skip a set outright, which writes no row at
+all rather than a number nobody performed.
 
 ### By Duration
 

--- a/docs/gameplay/quests.md
+++ b/docs/gameplay/quests.md
@@ -326,6 +326,14 @@ preview and the session that starts all read the same numbers. A level passed in
 adventure step) still wins over the remembered one. Stored values are re-clamped on read — they are
 untrusted text from SQLite.
 
+The swap sheet reaches this config from the quest screen, and **only** from there. The same sheet
+opened mid-session changes the movement for that session and writes nothing: the two are different
+acts. Configuring is posted cold, before starting, because the hero has no parallel bars at home;
+a mid-set swap is a correction for tonight, on the movement that just turned out to be out of
+reach. Storing the second would pin the slot — `applyQuestConfig` swaps before `currentRungFor`
+runs — so the rung substitution above would stop applying to the one slot the hero struggled on.
+Costing them a tap next session is the cheaper mistake.
+
 ---
 
 ## 🎮 Design Philosophy

--- a/locales/en.json
+++ b/locales/en.json
@@ -471,6 +471,7 @@
     "village_growth_title": "Your village grows",
     "village_tier_up_title": "Your village grew!",
     "xp_overshoot": "incl. +{{count}} for beating your targets",
+    "skip_exercise": "I couldn't do this one",
     "xp_earned": "XP Earned",
     "warmup_title": "WARM-UP",
     "warmup_skip": "Skip warm-up",

--- a/locales/en.json
+++ b/locales/en.json
@@ -215,6 +215,7 @@
     "reward_xp_estimate": "up to +{{count}} XP",
     "seconds_per_rep": "tempo {{count}}s/rep",
     "ghost_last": "Last: {{value}}",
+    "served_easier_rung": "Working up to {{name}}",
     "swap_exercise": "Replace this movement",
     "swap_reason_easier": "An easier rung",
     "swap_reason_harder": "A harder rung",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -669,6 +669,7 @@
     "village_growth_title": "Ton village grandit",
     "village_tier_up_title": "Ton village a grandi !",
     "xp_overshoot": "dont +{{count}} pour avoir dépassé vos cibles",
+    "skip_exercise": "Je n'ai pas pu",
     "xp_earned": "XP gagnés",
     "warmup_title": "ÉCHAUFFEMENT",
     "warmup_skip": "Passer l'échauffement",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -571,6 +571,7 @@
     "rounds": "{{count}} manches",
     "seconds_per_rep": "tempo {{count}} s/rép",
     "ghost_last": "Dernier : {{value}}",
+    "served_easier_rung": "En route vers {{name}}",
     "swap_exercise": "Remplacer ce mouvement",
     "swap_reason_easier": "Un échelon plus facile",
     "swap_reason_harder": "Un échelon plus difficile",

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -144,6 +144,14 @@ interface SessionState {
 
   // Results Accumulator
   results: CompletedExerciseInput[];
+  /**
+   * Whether the set just left behind was skipped rather than logged.
+   *
+   * A skipped set writes no row, so `results[results.length - 1]` is a set from an earlier round —
+   * and the rest screen's "adjust the last one" stepper edits exactly that. Without this flag it
+   * would silently correct a set the hero is not looking at.
+   */
+  lastSetSkipped: boolean;
 
   /**
    * The row `saveSession` created, once it has. Held so a retry after a partial failure
@@ -180,6 +188,7 @@ interface SessionState {
 
   // Progression
   completeExercise: (resultValue: number) => void;
+  skipExercise: () => void;
   updateLastResult: (resultValue: number) => void;
   skipRest: () => void;
   addRestTime: (seconds: number) => void;
@@ -242,7 +251,66 @@ export type SavedSessionState = Pick<
   | "timerStartTimestamp"
   | "timerDuration"
   | "results"
+  | "lastSetSkipped"
 > & { savedAt: number };
+
+/**
+ * Where a session goes once a set is behind it: finished, resting, or straight into the next
+ * movement.
+ *
+ * Shared by `completeExercise` and `skipExercise`, which differ only in whether the set left a
+ * result behind. The advance itself is identical, and two copies of it would drift — the rest
+ * choice alone carries the `??` that separates "no rest screen between rounds" from "fall back to
+ * restSeconds".
+ */
+function advanceAfterSet(
+  quest: Quest,
+  currentRoundIndex: number,
+  currentExerciseIndex: number,
+  results: CompletedExerciseInput[],
+): Partial<SessionState> {
+  const isLastExerciseInRound = currentExerciseIndex === quest.exercises.length - 1;
+  const isLastRound = currentRoundIndex === quest.rounds - 1;
+
+  if (isLastExerciseInRound && isLastRound) {
+    return { status: "finished", results, timerStartTimestamp: null, timerDuration: 0 };
+  }
+
+  const nextRound = isLastExerciseInRound ? currentRoundIndex + 1 : currentRoundIndex;
+  const nextExercise = isLastExerciseInRound ? 0 : currentExerciseIndex + 1;
+
+  // The last exercise of a round means the round is over — the last-round case already returned
+  // as "finished" above — so the longer round rest applies. `??`, not `||`: a round rest of 0
+  // means "no rest screen between rounds", not "fall back to restSeconds".
+  const restSeconds = isLastExerciseInRound
+    ? (quest.roundRestSeconds ?? quest.restSeconds)
+    : quest.restSeconds;
+
+  // The indices point at the *next* movement either way, so the rest screen can say what is
+  // coming up.
+  if (restSeconds > 0) {
+    return {
+      status: "resting",
+      results,
+      currentRoundIndex: nextRound,
+      currentExerciseIndex: nextExercise,
+      timerStartTimestamp: Date.now(),
+      timerDuration: restSeconds,
+    };
+  }
+
+  const nextExDef = quest.exercises[nextExercise];
+  const isNextTimeBased = nextExDef?.target.type === "time";
+
+  return {
+    status: "running",
+    results,
+    currentRoundIndex: nextRound,
+    currentExerciseIndex: nextExercise,
+    timerStartTimestamp: isNextTimeBased ? Date.now() : null,
+    timerDuration: isNextTimeBased ? nextExDef.target.value : 0,
+  };
+}
 
 /**
  * The session's results paired back with the movements that produced them.
@@ -405,6 +473,7 @@ export const useSessionStore = create<SessionState>()(
     timerStartTimestamp: null,
     timerDuration: 0,
     results: [],
+    lastSetSkipped: false,
     savedSessionId: null,
     triumphBonusPaid: false,
 
@@ -455,6 +524,7 @@ export const useSessionStore = create<SessionState>()(
           ? (warmupSequence[0]?.seconds ?? PRE_START_COUNTDOWN_SECONDS)
           : PRE_START_COUNTDOWN_SECONDS,
         results: [],
+        lastSetSkipped: false,
         savedSessionId: null,
         triumphBonusPaid: false,
       });
@@ -613,12 +683,12 @@ export const useSessionStore = create<SessionState>()(
         timerStartTimestamp: null,
         timerDuration: 0,
         results: [],
+        lastSetSkipped: false,
         savedSessionId: null,
         triumphBonusPaid: false,
       });
     },
 
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Complex exercise completion logic, refactor planned
     completeExercise: (resultValue) => {
       const { quest, currentRoundIndex, currentExerciseIndex, results, bossFight } = get();
       if (!quest) return;
@@ -674,65 +744,37 @@ export const useSessionStore = create<SessionState>()(
         performedAt: new Date(),
       };
 
-      const nextResults = [...results, newResult];
+      set({
+        ...advanceAfterSet(quest, currentRoundIndex, currentExerciseIndex, [...results, newResult]),
+        lastSetSkipped: false,
+      });
+    },
 
-      // Determine next step
-      const isLastExerciseInRound = currentExerciseIndex === quest.exercises.length - 1;
-      const isLastRound = currentRoundIndex === quest.rounds - 1;
+    /**
+     * The hero could not do this movement, and says so instead of typing a number.
+     *
+     * Writes nothing. `CHECK (resultValue > 0)` made "1" the only way past a movement out of
+     * reach, and that 1 then fed muscle volume, the weak-area read and the targets it generates —
+     * issue #33's second half, where the app taught its own journal a lie. A set that left no row
+     * is counted by nothing, with no reader having to remember to filter it out.
+     */
+    skipExercise: () => {
+      const { quest, currentRoundIndex, currentExerciseIndex, results } = get();
+      if (!quest) return;
 
-      if (isLastExerciseInRound && isLastRound) {
-        // FINISHED
-        set({
-          status: "finished",
-          results: nextResults,
-          timerStartTimestamp: null,
-          timerDuration: 0,
-        });
-        return;
-      }
+      // A session with nothing in it cannot be written — `createCompletedSession` refuses, and
+      // the victory screen would sit on a retry button that can never succeed. So the last
+      // remaining set is not skippable: the way out of a workout the hero cannot do is Quit,
+      // which the pause overlay already offers with a confirmation.
+      const isLastSet =
+        currentExerciseIndex === quest.exercises.length - 1 &&
+        currentRoundIndex === quest.rounds - 1;
+      if (isLastSet && results.length === 0) return;
 
-      // Not finished, so we are either moving to next exercise or next round
-      let nextRound = currentRoundIndex;
-      let nextExercise = currentExerciseIndex + 1;
-
-      if (isLastExerciseInRound) {
-        nextRound = currentRoundIndex + 1;
-        nextExercise = 0;
-      }
-
-      // Handle Rest. The last exercise of a round means the round is over — the last-round case
-      // already returned as "finished" above — so the longer round rest applies. `??`, not `||`:
-      // a round rest of 0 means "no rest screen between rounds", not "fall back to restSeconds".
-      const restSeconds = isLastExerciseInRound
-        ? (quest.roundRestSeconds ?? quest.restSeconds)
-        : quest.restSeconds;
-
-      // If we have rest, we go to resting state.
-      // The indices (round/exercise) will point to the NEXT exercise,
-      // so the UI can show "Up Next: [Next Exercise]".
-      if (restSeconds > 0) {
-        set({
-          status: "resting",
-          results: nextResults,
-          currentRoundIndex: nextRound,
-          currentExerciseIndex: nextExercise,
-          timerStartTimestamp: Date.now(),
-          timerDuration: restSeconds,
-        });
-      } else {
-        // No rest, jump straight to next
-        const nextExDef = quest.exercises[nextExercise];
-        const isNextTimeBased = nextExDef?.target.type === "time";
-
-        set({
-          status: "running",
-          results: nextResults,
-          currentRoundIndex: nextRound,
-          currentExerciseIndex: nextExercise,
-          timerStartTimestamp: isNextTimeBased ? Date.now() : null,
-          timerDuration: isNextTimeBased ? nextExDef.target.value : 0,
-        });
-      }
+      set({
+        ...advanceAfterSet(quest, currentRoundIndex, currentExerciseIndex, results),
+        lastSetSkipped: true,
+      });
     },
 
     skipRest: () => {
@@ -1073,6 +1115,7 @@ useSessionStore.subscribe(
           timerStartTimestamp: state.timerStartTimestamp,
           timerDuration: state.timerDuration,
           results: state.results,
+          lastSetSkipped: state.lastSetSkipped,
           savedAt: Date.now(),
         };
         await preferences.setSavedSession(JSON.stringify(savedState));

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -21,12 +21,12 @@ import {
   markSessionWithNewRecords,
 } from "@/db/completed";
 import { estimateQuestSeconds } from "@/db/estimate";
-import { checkForNewRungs, type VariationStep } from "@/db/exercises";
+import { checkForNewRungs, type Exercise, type VariationStep } from "@/db/exercises";
 import { checkOathFulfilled, OATH_XP_BONUS, type OathProgress } from "@/db/oaths";
 import { checkForNewRecords, type NewRecordResult } from "@/db/personalRecords";
 import { preferences } from "@/db/preferences";
 import { clearShortLivedQueries } from "@/db/queryCache";
-import { REST_RANGE, TARGET_RANGE } from "@/db/questConfig";
+import { getQuestConfig, REST_RANGE, saveQuestConfig, TARGET_RANGE } from "@/db/questConfig";
 import { invalidateQuestTemplates, isDailyQuest, type Quest } from "@/db/quests";
 import type { DifficultyCode, FeedbackCode, MuscleCode, QuestTargetType } from "@/db/schema";
 import { updateStreakAfterSession } from "@/db/streaks";
@@ -189,6 +189,7 @@ interface SessionState {
   // Progression
   completeExercise: (resultValue: number) => void;
   skipExercise: () => void;
+  swapCurrentExercise: (exercise: Exercise) => void;
   updateLastResult: (resultValue: number) => void;
   skipRest: () => void;
   addRestTime: (seconds: number) => void;
@@ -253,6 +254,31 @@ export type SavedSessionState = Pick<
   | "results"
   | "lastSetSkipped"
 > & { savedAt: number };
+
+/**
+ * Remember a mid-session swap, so the quest opens on the movement the hero chose next time.
+ *
+ * The target override goes with the movement it was tuned for — "20" carried from push-ups onto a
+ * one-arm push-up is a bad prescription, the reasoning `applySwap` spells out on the quest screen.
+ */
+async function persistSwap(
+  questId: number,
+  questExerciseId: number,
+  exerciseId: number,
+  userLevel: DifficultyCode,
+): Promise<void> {
+  const config = await getQuestConfig(questId);
+  const { [String(questExerciseId)]: _replaced, ...targets } = config?.targets ?? {};
+
+  await saveQuestConfig(questId, {
+    ...config,
+    // `level` is required on the stored shape; a quest never configured has none yet, and the
+    // session is running at the one the hero started it with.
+    level: config?.level ?? userLevel,
+    targets,
+    swaps: { ...config?.swaps, [String(questExerciseId)]: exerciseId },
+  });
+}
 
 /**
  * Where a session goes once a set is behind it: finished, resting, or straight into the next
@@ -324,7 +350,17 @@ function toXpSets(quest: Quest, results: CompletedExerciseInput[]): XpSet[] {
     const slot = quest.exercises[r.sortOrder];
     if (!slot) return [];
 
-    return [{ exercise: slot.exercise, target: r.target ?? slot.target, result: r.result }];
+    // `r.pricing` before `slot.exercise`, for the same reason `r.target` comes before
+    // `slot.target`: a slot can change mid-session now, and a set is priced by what it was, not
+    // by what the slot became. Without this, swapping to a `hard` movement on the last round
+    // re-prices every set already logged and inflates the whole workout.
+    return [
+      {
+        exercise: r.pricing ?? slot.exercise,
+        target: r.target ?? slot.target,
+        result: r.result,
+      },
+    ];
   });
 }
 
@@ -741,6 +777,10 @@ export const useSessionStore = create<SessionState>()(
         sortOrder: currentExerciseIndex,
         result: { type: currentEx.target.type, value: safeResultValue },
         target: { type: currentEx.target.type, value: currentEx.target.value },
+        pricing: {
+          secondsPerRep: currentEx.exercise.secondsPerRep,
+          difficulty: currentEx.exercise.difficulty,
+        },
         performedAt: new Date(),
       };
 
@@ -758,6 +798,59 @@ export const useSessionStore = create<SessionState>()(
      * issue #33's second half, where the app taught its own journal a lie. A set that left no row
      * is counted by nothing, with no reader having to remember to filter it out.
      */
+    /**
+     * Change the movement in front of the hero, mid-set.
+     *
+     * The swap sheet existed already, but only on the quest screen — before starting, which is
+     * not when a hero discovers a movement is out of reach (issue #33). Reaching it from here is
+     * what lets them log what they actually did instead of typing the lowest number the field
+     * accepts.
+     */
+    swapCurrentExercise: (exercise) => {
+      const { quest, currentExerciseIndex, status } = get();
+      if (!quest || (status !== "running" && status !== "resting")) return;
+
+      const slot = quest.exercises[currentExerciseIndex];
+      if (!slot || slot.exercise.id === exercise.id) return;
+
+      // The target belongs to the slot, not to the movement — same call `applyQuestConfig` makes.
+      // Results already logged keep their own `exerciseId` and `pricing`: they are true.
+      const exercises = quest.exercises.map((qex, i) =>
+        i === currentExerciseIndex
+          ? {
+              ...qex,
+              exercise,
+              // The quest's art is of the movement that used to be here, and the caption named a
+              // rung the hero has just overruled.
+              images: [],
+              ghost: undefined,
+              substitutedFor: undefined,
+            }
+          : qex,
+      );
+
+      // Every other entry into a movement sets this pair, and the two units are not
+      // interchangeable: a hold timer left running on a rep movement counts nothing down, and reps
+      // arrived at with no timer would show seconds that never started.
+      const isTimeBased = slot.target.type === "time";
+
+      set({
+        quest: { ...quest, exercises },
+        ...(status === "running"
+          ? {
+              timerStartTimestamp: isTimeBased ? Date.now() : null,
+              timerDuration: isTimeBased ? slot.target.value : 0,
+            }
+          : {}),
+      });
+
+      // Stick for next time. Never blocking: a preference that fails to save must not take a
+      // workout down with it.
+      persistSwap(quest.id, slot.id, exercise.id, get().userLevel).catch((e) =>
+        reportError("session.swap", e),
+      );
+    },
+
     skipExercise: () => {
       const { quest, currentRoundIndex, currentExerciseIndex, results } = get();
       if (!quest) return;

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -26,7 +26,7 @@ import { checkOathFulfilled, OATH_XP_BONUS, type OathProgress } from "@/db/oaths
 import { checkForNewRecords, type NewRecordResult } from "@/db/personalRecords";
 import { preferences } from "@/db/preferences";
 import { clearShortLivedQueries } from "@/db/queryCache";
-import { getQuestConfig, REST_RANGE, saveQuestConfig, TARGET_RANGE } from "@/db/questConfig";
+import { REST_RANGE, TARGET_RANGE } from "@/db/questConfig";
 import { invalidateQuestTemplates, isDailyQuest, type Quest } from "@/db/quests";
 import type { DifficultyCode, FeedbackCode, MuscleCode, QuestTargetType } from "@/db/schema";
 import { updateStreakAfterSession } from "@/db/streaks";
@@ -254,31 +254,6 @@ export type SavedSessionState = Pick<
   | "results"
   | "lastSetSkipped"
 > & { savedAt: number };
-
-/**
- * Remember a mid-session swap, so the quest opens on the movement the hero chose next time.
- *
- * The target override goes with the movement it was tuned for — "20" carried from push-ups onto a
- * one-arm push-up is a bad prescription, the reasoning `applySwap` spells out on the quest screen.
- */
-async function persistSwap(
-  questId: number,
-  questExerciseId: number,
-  exerciseId: number,
-  userLevel: DifficultyCode,
-): Promise<void> {
-  const config = await getQuestConfig(questId);
-  const { [String(questExerciseId)]: _replaced, ...targets } = config?.targets ?? {};
-
-  await saveQuestConfig(questId, {
-    ...config,
-    // `level` is required on the stored shape; a quest never configured has none yet, and the
-    // session is running at the one the hero started it with.
-    level: config?.level ?? userLevel,
-    targets,
-    swaps: { ...config?.swaps, [String(questExerciseId)]: exerciseId },
-  });
-}
 
 /**
  * Where a session goes once a set is behind it: finished, resting, or straight into the next
@@ -844,11 +819,13 @@ export const useSessionStore = create<SessionState>()(
           : {}),
       });
 
-      // Stick for next time. Never blocking: a preference that fails to save must not take a
-      // workout down with it.
-      persistSwap(quest.id, slot.id, exercise.id, get().userLevel).catch((e) =>
-        reportError("session.swap", e),
-      );
+      // Deliberately not written to the quest's saved config, unlike the same sheet on the quest
+      // screen. That one is configuration — posted cold, before starting, because the hero has no
+      // parallel bars at home. This one is a correction for tonight, made mid-set on the movement
+      // that just turned out to be out of reach, and reading a standing preference out of it pins
+      // the slot: `applyQuestConfig` swaps before `currentRungFor` ever runs, so the progression
+      // substitution issue #33 exists for stops applying to the one slot the hero struggled on.
+      // Costing them a tap next session is the cheaper mistake; the quest screen still pins.
     },
 
     skipExercise: () => {

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -27,7 +27,7 @@ import { checkForNewRecords, type NewRecordResult } from "@/db/personalRecords";
 import { preferences } from "@/db/preferences";
 import { clearShortLivedQueries } from "@/db/queryCache";
 import { REST_RANGE, TARGET_RANGE } from "@/db/questConfig";
-import { isDailyQuest, type Quest } from "@/db/quests";
+import { invalidateQuestTemplates, isDailyQuest, type Quest } from "@/db/quests";
 import type { DifficultyCode, FeedbackCode, MuscleCode, QuestTargetType } from "@/db/schema";
 import { updateStreakAfterSession } from "@/db/streaks";
 import { calculateLevelFromXp, getTotalXp } from "@/db/userLevel";
@@ -979,6 +979,14 @@ export const useSessionStore = create<SessionState>()(
       // apart. Without this, "after" replayed the pre-session volumes and no muscle-driven
       // building ever appeared to grow on the victory screen.
       clearShortLivedQueries();
+
+      // A different cache, and a different reason. `getQuestById` memoizes a resolved quest per
+      // (id, level) with no TTL, and what it resolves now depends on the journal: the third
+      // on-target session earns a rung, which is exactly when a slot should stop being substituted
+      // down (issue #33). Without this the hero climbs and keeps being handed the easier movement
+      // until the app restarts.
+      invalidateQuestTemplates();
+
       const afterBuildings = await getVillageBuildings();
       const villageGrowth = diffVillageGrowth(beforeBuildings, afterBuildings);
 


### PR DESCRIPTION
Closes #33.

## The report

A beginner did wall push-ups on day one. On day two "Chop Wood" handed them classical push-ups. They entered **"1"** — the lowest the field accepts — and went off to do incline push-ups instead.

Three defects combine, all verified:

- The beginner filter only hides `advanced` quests. "Chop Wood" is three `medium` movements, so it reads `regular` and **28 of 34 quests stay on offer**.
- Difficulty scales reps and never swaps the movement: `easy` turns ten impossible push-ups into seven.
- `CHECK (resultValue > 0)` leaves no honest way to say "I could not do this".

The galling part is that the ladder already recorded Push-ups as requiring Knee Push-Up, requiring Wall Push-Up. **The movement the reporter expected is the recorded prerequisite of the one he was served.** And that "1" now feeds muscle volume, the weak-area read and every target generated from them — the app taught its own journal a lie because it left no other way forward.

## What changed

**A slot serves the rung the hero is on.** `getQuestById` resolves each slot by the same `isEarned` rule the exercise screen shows, so the app stops prescribing what it is simultaneously telling the hero to work up to. On the reporter's day two — one wall session against the three a rung needs — the push-up slot serves Wall Push-Up. That is the test that defines "fixed".

**A set can be skipped**, writing no row at all. Nothing counts it and no reader has to remember to filter it. That is why the shape is an absent row rather than a `skipped` column: a flag would still need a fake `1` in the value column and five separate readers keeping the faith forever.

**The swap sheet opens mid-session.** It always existed, but only on the quest screen — before starting, which is not when a hero discovers a movement is out of reach.

**Both surfaces say so.** "Working up to Push-ups" on the quest card and in the session, because a quest that quietly shows something other than its own card reads as a bug — and a hero who thinks the app got it wrong is a hero who logs a lie.

## Two traps worth the review

**The swap would have re-priced sets already logged.** `toXpSets` re-read the movement off the quest slot at save time. Harmless while a slot is fixed for a whole session; wrong the moment one can change — swapping to a `hard` movement on the last round would have inflated the entire workout by up to 2.5×. A set now carries its own `pricing`, captured when it was done. The phase closing one abuse came within a field of opening another.

**The quest cache has no TTL.** `getQuestById` memoizes per (id, level), and what it resolves depends on the journal: the third on-target session earns a rung, which is exactly when a slot should stop being substituted. `saveSession` now invalidates it — without that the hero climbs and keeps being handed the easier movement until the app restarts.

## Test infrastructure

Three mocks were flat object literals, so every symbol added to `db/xp`, `db/quests` or `db/queryCache` arrived `undefined` with no error anywhere. They now spread the real module, the idiom `@/db/bossFights` already used.

`ownEveryRung` is the other half: content invariants describe the catalogue as authored, and on an empty journal every quest now resolves to the bottom of every chain. A hero who owns everything sees the quest as written, so that is the hero those tests use.

## Verification

- **951 tests**, `biome --error-on-warnings` and `tsc` clean across the repo, knip empty, expo-doctor 20/20, Android bundle exits 0.
- Not yet run on a device. The end-to-end replay — blank account, one wall push-up session, "Chop Wood" the next day — is covered by an automated test, but the two new controls have only been seen by the type checker.

## Not in scope

Tightening `getEligibleQuestIds` so a beginner sees only `beginner` quests: one line, but it leaves 9 of 34 and does not answer the request — he wanted the right movement, not fewer choices. After this, moot.

The reporter's second bug ("swipe through the progressions" in the catalogue) is separate and needs its own reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)