### PR TITLE
Le ressenti nourrit la prescription (roadmap §4.5)

### DIFF
--- a/__tests__/adventure-details-cta.test.tsx
+++ b/__tests__/adventure-details-cta.test.tsx
@@ -77,7 +77,7 @@ jest.mock("@/db", () => ({
   listExercises: jest.fn().mockResolvedValue([]),
   getRecentSessionHistory: jest.fn().mockResolvedValue([]),
   startAdventureRun: jest.fn(),
-  suggestDifficultyFromSessions: jest.fn().mockReturnValue("medium"),
+  suggestDifficultyFromSessions: jest.fn().mockReturnValue({ level: "medium", adjusted: false }),
   estimateQuestTemplateSeconds: jest.fn().mockReturnValue(300),
   estimateQuestTemplateXp: jest.fn().mockReturnValue(60),
   adventureWeeks: jest.fn().mockReturnValue(1),
@@ -165,7 +165,7 @@ test.each([
   ["hard", "Hard"],
 ])("the tag wears the suggested difficulty (%s)", async (suggested, label) => {
   const db = require("@/db") as { suggestDifficultyFromSessions: jest.Mock };
-  db.suggestDifficultyFromSessions.mockReturnValue(suggested);
+  db.suggestDifficultyFromSessions.mockReturnValue({ level: suggested, adjusted: false });
 
   const { findByText } = await render(
     <TamaguiProvider config={config} defaultTheme="dark">
@@ -174,4 +174,35 @@ test.each([
   );
 
   expect(await findByText(label)).toBeTruthy();
+});
+
+// The screen carries no difficulty control, so a level that moves on its own has to say why —
+// otherwise the hero sees their adventure harden with nothing to point at.
+describe("the caption under the tag", () => {
+  const suggestion = () =>
+    (require("@/db") as { suggestDifficultyFromSessions: jest.Mock }).suggestDifficultyFromSessions;
+
+  const renderScreen = () =>
+    render(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <AdventureDetailsScreen />
+      </TamaguiProvider>,
+    );
+
+  test("appears when the feeling moved the level", async () => {
+    suggestion().mockReturnValue({ level: "hard", adjusted: true });
+
+    const { findByText } = await renderScreen();
+
+    expect(await findByText("Adjusted from your feedback")).toBeTruthy();
+  });
+
+  test("stays away when the level is the hero's own doing", async () => {
+    suggestion().mockReturnValue({ level: "hard", adjusted: false });
+
+    const { findByText, queryByText } = await renderScreen();
+
+    await findByText("Hard");
+    expect(queryByText("Adjusted from your feedback")).toBeNull();
+  });
 });

--- a/__tests__/adventure-details-cta.test.tsx
+++ b/__tests__/adventure-details-cta.test.tsx
@@ -194,7 +194,7 @@ describe("the caption under the tag", () => {
 
     const { findByText } = await renderScreen();
 
-    expect(await findByText("Adjusted from your feedback")).toBeTruthy();
+    expect(await findByText("From your feedback")).toBeTruthy();
   });
 
   test("stays away when the level is the hero's own doing", async () => {
@@ -203,6 +203,6 @@ describe("the caption under the tag", () => {
     const { findByText, queryByText } = await renderScreen();
 
     await findByText("Hard");
-    expect(queryByText("Adjusted from your feedback")).toBeNull();
+    expect(queryByText("From your feedback")).toBeNull();
   });
 });

--- a/__tests__/db-completed-trends.test.ts
+++ b/__tests__/db-completed-trends.test.ts
@@ -91,13 +91,23 @@ describe("db/completed — history and trends", () => {
       expect([...times].sort((a, b) => a - b)).toEqual(times);
     });
 
-    it("honours the limit", async () => {
+    // The limit must bite the *old* end. Asserting only the count passed while the query
+    // returned the oldest two — which is what froze the chart and the difficulty suggestion
+    // on the first ten sessions a hero ever banked.
+    it("drops the oldest sessions when the limit bites", async () => {
       const now = new Date();
       await bankSession({ performedAt: subDays(now, 3) });
       await bankSession({ performedAt: subDays(now, 2) });
       await bankSession({ performedAt: subDays(now, 1) });
 
-      expect((await completed().getRecentSessionHistory(2)).length).toBe(2);
+      const history = await completed().getRecentSessionHistory(2);
+
+      // Stored as a unix second, so the millis the test built with do not survive the round trip.
+      const seconds = (d: Date) => Math.floor(d.getTime() / 1000);
+      expect(history.map((h) => seconds(h.performedAt))).toEqual([
+        seconds(subDays(now, 2)),
+        seconds(subDays(now, 1)),
+      ]);
     });
 
     it("keeps a quest's history to that quest", async () => {
@@ -116,6 +126,27 @@ describe("db/completed — history and trends", () => {
 
       expect(history.length).toBe(2);
       expect(history.every((h) => h.questId === target.id)).toBe(true);
+    });
+
+    it("drops a quest's oldest sessions when the limit bites", async () => {
+      const now = new Date();
+      const target = t.sqlite.prepare("SELECT id FROM quests LIMIT 1").get() as
+        | { id: number }
+        | undefined;
+      if (!target) throw new Error("No seeded quests");
+
+      await bankSession({ performedAt: subDays(now, 3), questId: target.id });
+      await bankSession({ performedAt: subDays(now, 2), questId: target.id });
+      await bankSession({ performedAt: subDays(now, 1), questId: target.id });
+
+      const history = await completed().getQuestSessionHistory(target.id, 2);
+
+      // Stored as a unix second, so the millis the test built with do not survive the round trip.
+      const seconds = (d: Date) => Math.floor(d.getTime() / 1000);
+      expect(history.map((h) => seconds(h.performedAt))).toEqual([
+        seconds(subDays(now, 2)),
+        seconds(subDays(now, 1)),
+      ]);
     });
 
     it("returns nothing for a quest never played", async () => {

--- a/__tests__/difficultySuggestion.test.ts
+++ b/__tests__/difficultySuggestion.test.ts
@@ -1,20 +1,32 @@
 import type { SessionSummary } from "../db/completed";
 import { suggestDifficultyFromSessions } from "../db/difficultySuggestion";
+import type { FeedbackCode } from "../db/schema";
 
-function session(level: "easy" | "medium" | "hard", id: number): SessionSummary {
+function session(
+  level: "easy" | "medium" | "hard",
+  id: number,
+  feedback: FeedbackCode | null = null,
+): SessionSummary {
   return {
     id,
     questId: 1,
     userLevel: level,
     durationSeconds: 60,
     performedAt: new Date(2024, 0, id),
-    feedback: null,
+    feedback,
   };
+}
+
+/** Five sessions at one level, the last `reported` of them carrying a feeling. */
+function fiveAt(level: "easy" | "medium" | "hard", feedback: FeedbackCode | null, reported = 0) {
+  return Array.from({ length: 5 }, (_, i) =>
+    session(level, i + 1, i >= 5 - reported ? feedback : null),
+  );
 }
 
 describe("db/difficultySuggestion", () => {
   test("defaults to medium with no history", () => {
-    expect(suggestDifficultyFromSessions([])).toBe("medium");
+    expect(suggestDifficultyFromSessions([]).level).toBe("medium");
   });
 
   test("suggests hard when recent average is high", () => {
@@ -24,7 +36,7 @@ describe("db/difficultySuggestion", () => {
       session("hard", 3),
       session("medium", 4),
     ];
-    expect(suggestDifficultyFromSessions(sessions)).toBe("hard");
+    expect(suggestDifficultyFromSessions(sessions).level).toBe("hard");
   });
 
   test("suggests easy when recent average is low", () => {
@@ -34,7 +46,7 @@ describe("db/difficultySuggestion", () => {
       session("medium", 3),
       session("easy", 4),
     ];
-    expect(suggestDifficultyFromSessions(sessions)).toBe("easy");
+    expect(suggestDifficultyFromSessions(sessions).level).toBe("easy");
   });
 
   test("suggests medium when mixed", () => {
@@ -44,6 +56,55 @@ describe("db/difficultySuggestion", () => {
       session("hard", 3),
       session("medium", 4),
     ];
-    expect(suggestDifficultyFromSessions(sessions)).toBe("medium");
+    expect(suggestDifficultyFromSessions(sessions).level).toBe("medium");
+  });
+
+  describe("the feeling moves the suggestion", () => {
+    // The whole point of roadmap 4.5: answering "too easy" has to reach the level the app picks,
+    // not just render a card in the Journal.
+    test("three 'too easy' out of five raise it one rung", () => {
+      expect(suggestDifficultyFromSessions(fiveAt("medium", "easy", 3))).toEqual({
+        level: "hard",
+        adjusted: true,
+      });
+    });
+
+    test("three 'too hard' out of five lower it one rung", () => {
+      expect(suggestDifficultyFromSessions(fiveAt("medium", "hard", 3))).toEqual({
+        level: "easy",
+        adjusted: true,
+      });
+    });
+
+    // A hero who never answers the question must see exactly what they saw before this feature.
+    test("silence changes nothing", () => {
+      expect(suggestDifficultyFromSessions(fiveAt("medium", null))).toEqual({
+        level: "medium",
+        adjusted: false,
+      });
+    });
+
+    // The flag is not "was there a verdict" but "did the level actually move" — the screen shows
+    // a caption from it, and a caption over an unchanged level is a lie.
+    test("'too easy' at the top rung reports nothing to say", () => {
+      expect(suggestDifficultyFromSessions(fiveAt("hard", "easy", 3))).toEqual({
+        level: "hard",
+        adjusted: false,
+      });
+    });
+
+    test("'too hard' at the bottom rung reports nothing to say", () => {
+      expect(suggestDifficultyFromSessions(fiveAt("easy", "hard", 3))).toEqual({
+        level: "easy",
+        adjusted: false,
+      });
+    });
+
+    // Under three sessions analyzeDifficultyProgression abstains, so a first week is never moved.
+    test("two sessions are not enough to move anything", () => {
+      expect(
+        suggestDifficultyFromSessions([session("medium", 1, "easy"), session("medium", 2, "easy")]),
+      ).toEqual({ level: "medium", adjusted: false });
+    });
   });
 });

--- a/app/(tabs)/adventures/[id].tsx
+++ b/app/(tabs)/adventures/[id].tsx
@@ -399,8 +399,11 @@ export default function AdventureDetailsScreen() {
     <YStack flex={1} bg="$background">
       <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom + 100 }}>
         <YStack p="$5" pt={insets.top + 12} gap="$4">
-          <XStack items="center" justify="space-between">
-            <XStack items="center" gap="$3">
+          <XStack items="center" justify="space-between" gap="$2">
+            {/* Same rule as the exercises header: only the title gives way. Yoga's flexShrink
+                defaults to 0, so without this the level column kept its natural width and pushed
+                its caption off the screen edge, across the title. */}
+            <XStack items="center" gap="$3" flex={1} minW={0}>
               <AppIconButton
                 onPress={() => router.back()}
                 accessibilityRole="button"
@@ -409,9 +412,16 @@ export default function AdventureDetailsScreen() {
                 <ChevronLeft size={22} color="$text" strokeWidth={2.5} />
               </AppIconButton>
 
-              <XStack items="center" gap="$2">
+              <XStack items="center" gap="$2" flex={1} minW={0}>
                 <Sparkles size={18} color="$primaryText" />
-                <Text fontWeight="700" fontSize={20} color="$text">
+                <Text
+                  flex={1}
+                  minW={0}
+                  fontWeight="700"
+                  fontSize={20}
+                  color="$text"
+                  numberOfLines={1}
+                >
                   {t("adventures.details_title")}
                 </Text>
               </XStack>
@@ -422,7 +432,7 @@ export default function AdventureDetailsScreen() {
               {/* Only when the shown level *is* the suggestion: a pinned run displays its own
                   starting level, and the caption would be describing something else. */}
               {feedbackAdjusted && !run?.run.difficultyOverride ? (
-                <Paragraph color="$textSecondary" size="$3">
+                <Paragraph color="$textSecondary" size="$2" numberOfLines={1}>
                   {t("adventures.level_from_feedback")}
                 </Paragraph>
               ) : null}

--- a/app/(tabs)/adventures/[id].tsx
+++ b/app/(tabs)/adventures/[id].tsx
@@ -58,6 +58,8 @@ type LoadedData = {
   activeRun: ActiveAdventureRun | null;
   exercisesById: Record<number, Exercise>;
   suggestedDifficulty: "easy" | "medium" | "hard";
+  /** Whether the hero's post-session feedback moved that suggestion off their own choices. */
+  feedbackAdjusted: boolean;
   /** Null until the campaign's first session creates the fight, and for every non-boss adventure. */
   bossFight: BossFight | null;
 };
@@ -193,6 +195,7 @@ export default function AdventureDetailsScreen() {
     activeRun: null,
     exercisesById: {},
     suggestedDifficulty: "medium",
+    feedbackAdjusted: false,
     bossFight: null,
   });
 
@@ -223,6 +226,7 @@ export default function AdventureDetailsScreen() {
             activeRun: null,
             exercisesById: {},
             suggestedDifficulty: "medium",
+            feedbackAdjusted: false,
             bossFight: null,
             message: t("adventures.not_found"),
           });
@@ -230,7 +234,7 @@ export default function AdventureDetailsScreen() {
         }
 
         const exercisesById = Object.fromEntries(exercises.map((e) => [e.id, e] as const));
-        const suggestedDifficulty = suggestDifficultyFromSessions(history, {
+        const suggestion = suggestDifficultyFromSessions(history, {
           maxSessions: 10,
           defaultDifficulty: "medium",
         });
@@ -240,7 +244,8 @@ export default function AdventureDetailsScreen() {
           details,
           activeRun,
           exercisesById,
-          suggestedDifficulty,
+          suggestedDifficulty: suggestion.level,
+          feedbackAdjusted: suggestion.adjusted,
           bossFight,
         });
       } catch (e) {
@@ -274,8 +279,11 @@ export default function AdventureDetailsScreen() {
   const details = state.details;
   const run = state.activeRun;
   const suggestedDifficulty = state.suggestedDifficulty;
-  // A started run pins its difficulty for the whole campaign (schema comment on
-  // `difficultyOverride`); once set, every step must honor it instead of a fresh suggestion.
+  const feedbackAdjusted = state.feedbackAdjusted;
+  // `difficultyOverride` still pins a campaign when it is set, and runs started before the
+  // feedback link shipped carry one — they finish at the level they began. Nothing writes it any
+  // more: a fresh run follows the suggestion at every step, so answering "too hard" mid-campaign
+  // eases the next one instead of waiting weeks for the next campaign.
   const effectiveDifficulty = run?.run.difficultyOverride ?? suggestedDifficulty;
 
   const langKey = language;
@@ -350,8 +358,7 @@ export default function AdventureDetailsScreen() {
 
     setIsStarting(true);
     try {
-      const nextRun =
-        run ?? (await startAdventureRun({ adventureId, difficultyOverride: suggestedDifficulty }));
+      const nextRun = run ?? (await startAdventureRun({ adventureId }));
       const step =
         nextRun.activeStep ??
         nextRun.steps.find((s) => s.status === "active") ??
@@ -410,7 +417,16 @@ export default function AdventureDetailsScreen() {
               </XStack>
             </XStack>
 
-            <Tag label={levelLabel(effectiveDifficulty, t)} tone="secondary" />
+            <YStack items="flex-end" gap="$1">
+              <Tag label={levelLabel(effectiveDifficulty, t)} tone="secondary" />
+              {/* Only when the shown level *is* the suggestion: a pinned run displays its own
+                  starting level, and the caption would be describing something else. */}
+              {feedbackAdjusted && !run?.run.difficultyOverride ? (
+                <Paragraph color="$textSecondary" size="$3">
+                  {t("adventures.level_from_feedback")}
+                </Paragraph>
+              ) : null}
+            </YStack>
           </XStack>
 
           {state.status === "error" ? (

--- a/db/completed.ts
+++ b/db/completed.ts
@@ -389,8 +389,11 @@ export type SessionSummary = {
 };
 
 /**
- * Get session history for a specific quest, ordered by date ascending.
- * Useful for building progression charts.
+ * Get a quest's most recent sessions, returned oldest-first so a chart reads left to right.
+ *
+ * The limit has to bite the old end, which is why the query sorts descending and the result is
+ * reversed: sorting ascending and limiting returns the *first* n sessions a hero ever banked,
+ * frozen there forever once they pass n.
  */
 export async function getQuestSessionHistory(
   questId: number,
@@ -407,10 +410,10 @@ export async function getQuestSessionHistory(
     })
     .from(completedQuest)
     .where(eq(completedQuest.questId, questId))
-    .orderBy(completedQuest.performedAt, completedQuest.id)
+    .orderBy(desc(completedQuest.performedAt), desc(completedQuest.id))
     .limit(limit);
 
-  return rows.map((r) => ({
+  return rows.reverse().map((r) => ({
     id: r.id,
     questId: r.questId ?? null,
     userLevel: r.userLevel,
@@ -421,8 +424,8 @@ export async function getQuestSessionHistory(
 }
 
 /**
- * Get recent session history across all quests, ordered by date ascending.
- * Useful for overall progression charts.
+ * The most recent sessions across all quests, returned oldest-first so a chart reads left to
+ * right. Same descending-then-reverse reason as `getQuestSessionHistory` above.
  */
 export async function getRecentSessionHistory(limit = 30): Promise<SessionSummary[]> {
   const rows = await db
@@ -435,10 +438,10 @@ export async function getRecentSessionHistory(limit = 30): Promise<SessionSummar
       feedback: completedQuest.feedback,
     })
     .from(completedQuest)
-    .orderBy(completedQuest.performedAt, completedQuest.id)
+    .orderBy(desc(completedQuest.performedAt), desc(completedQuest.id))
     .limit(limit);
 
-  return rows.map((r) => ({
+  return rows.reverse().map((r) => ({
     id: r.id,
     questId: r.questId ?? null,
     userLevel: r.userLevel,

--- a/db/difficultySuggestion.ts
+++ b/db/difficultySuggestion.ts
@@ -1,13 +1,41 @@
 import type { SessionSummary } from "./completed";
 import type { DifficultyCode } from "./schema";
 
+export type DifficultySuggestion = {
+  level: DifficultyCode;
+  /**
+   * Whether the feeling moved the level off what the hero's own choices asked for. The screen
+   * captions the level from this, so it has to mean "it actually moved", not "there was a
+   * verdict": `increase` at `hard` has nowhere to go, and a caption over an unchanged level lies.
+   */
+  adjusted: boolean;
+};
+
+const LADDER: DifficultyCode[] = ["easy", "medium", "hard"];
+
+/** One rung up or down, clamped at both ends. */
+function shift(level: DifficultyCode, by: -1 | 0 | 1): DifficultyCode {
+  const next = LADDER[Math.min(LADDER.length - 1, Math.max(0, LADDER.indexOf(level) + by))];
+  return next ?? level;
+}
+
+/**
+ * What level to propose next, from what the hero *did* — their last `maxSessions` choices — then
+ * moved one rung by what they *felt*, over the shorter window `analyzeDifficultyProgression`
+ * reads. Two windows on purpose: the choices are the baseline, the feeling is the correction.
+ *
+ * ponytail: the feeling window straddles a shift — three "too easy" reported at `medium` are
+ *           still in it after the move to `hard`, so they push once more. Ceiling: converges in
+ *           three reports either way and is symmetric, so it self-corrects. Count only the
+ *           feedback from sessions performed at the current level if that surprises anyone.
+ */
 export function suggestDifficultyFromSessions(
   sessions: SessionSummary[],
   options?: {
     maxSessions?: number;
     defaultDifficulty?: DifficultyCode;
   },
-): DifficultyCode {
+): DifficultySuggestion {
   const maxSessions = options?.maxSessions ?? 10;
   const fallback: DifficultyCode = options?.defaultDifficulty ?? "medium";
 
@@ -16,7 +44,7 @@ export function suggestDifficultyFromSessions(
     .map((s) => s.userLevel)
     .filter((v): v is DifficultyCode => v === "easy" || v === "medium" || v === "hard");
 
-  if (recent.length === 0) return fallback;
+  if (recent.length === 0) return { level: fallback, adjusted: false };
 
   const score = (level: DifficultyCode) => {
     if (level === "easy") return 0;
@@ -26,9 +54,12 @@ export function suggestDifficultyFromSessions(
 
   const avg = recent.reduce((acc, lvl) => acc + score(lvl), 0) / recent.length;
 
-  if (avg <= 0.75) return "easy";
-  if (avg >= 1.25) return "hard";
-  return "medium";
+  const chosen: DifficultyCode = avg <= 0.75 ? "easy" : avg >= 1.25 ? "hard" : "medium";
+
+  const { action } = analyzeDifficultyProgression(sessions);
+  const level = shift(chosen, action === "increase" ? 1 : action === "decrease" ? -1 : 0);
+
+  return { level, adjusted: level !== chosen };
 }
 
 export type ProgressionRecommendation = {

--- a/docs/architecture/database-api.md
+++ b/docs/architecture/database-api.md
@@ -254,8 +254,8 @@ interface TrendAnalysis {
 | `createCompletedSession(data)` | Save a completed session |
 | `listCompletedSessions(limit?)` | Get recent sessions |
 | `getCompletedSessionById(id)` | Get session with exercises |
-| `getRecentSessionHistory(questId, limit)` | Quest-specific history |
-| `getQuestSessionHistory(questId)` | Full history for quest |
+| `getRecentSessionHistory(limit?)` | Most recent sessions, all quests, oldest-first |
+| `getQuestSessionHistory(questId, limit?)` | Most recent sessions for one quest, oldest-first |
 | `getWeeklyTrends(weeks?)` | Get weekly trend data |
 | `getMonthlyTrends(months?)` | Get monthly trend data |
 | `analyzeTrend(current, previous)` | Compare two values |

--- a/docs/gameplay/adventures.md
+++ b/docs/gameplay/adventures.md
@@ -98,7 +98,8 @@ CREATE TABLE adventure_runs (
   id INTEGER PRIMARY KEY,
   adventureId INTEGER REFERENCES adventures(id),
   status TEXT NOT NULL,        -- 'active' | 'finished'
-  difficultyOverride TEXT,     -- Override quest difficulty
+  difficultyOverride TEXT,     -- Pins the campaign. Null in practice since the feedback link
+                               -- shipped: each step re-reads the suggestion instead.
   startedAt INTEGER,
   finishedAt INTEGER,
   createdAt INTEGER

--- a/docs/gameplay/session-flow.md
+++ b/docs/gameplay/session-flow.md
@@ -247,11 +247,18 @@ was there for it.
 └─────────────────────────────────────────────┘
 ```
 
-**Feedback Impact**:
+**Feedback Impact**: the answer moves the level an **adventure** proposes, one rung, and the
+adventure screen captions the tag when it did. It takes 3 of the last 5 sessions saying the same
+thing (`analyzeDifficultyProgression`), so one bad night changes nothing, and a hero who never
+answers is never moved — a missing answer counts as "good".
 
-- Easy → Suggest harder quests
-- Hard → Adjust difficulty, offer encouragement
-- Good → Continue current path
+- Easy ×3 → the next adventure step proposes one rung harder
+- Hard ×3 → one rung easier
+- Good, or no answer → unchanged
+
+A **quest** keeps the level the hero set on it: nothing here overrides a choice they made by
+hand. `suggestDifficultyFromSessions` is the single writer of this rule
+([`db/difficultySuggestion.ts`](../../db/difficultySuggestion.ts)).
 
 ---
 

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -218,7 +218,7 @@ cost as much thought as the takes, and by the third pass they outnumbered the fe
 | 4.3 | Immersive session: exercise art **and** audio | High | M | **P1** | Zombies, Run! |
 | 4.4 | ~~The variation ladder becomes visible~~ — **shipped as *paths*** | High | S | ✅ | calisthenics review |
 | 4.22 | ~~An exercise catalogue — the screen 4.4 needs~~ — **shipped** | High | S–M | ✅ | GymMane |
-| 4.5 | The feeling feeds the prescription | Med-high | S | **P1** | Freeletics |
+| 4.5 | ~~The feeling feeds the prescription~~ — **shipped** | Med-high | S | ✅ | Freeletics |
 | 4.6 | Boss battle refonte | High | M–L | **P1** | |
 | 4.7 | FR review of the exercise content | Med-high | S | **P1** | |
 | 4.8 | Stats refonte | Med-high | M | **P1** | |
@@ -486,24 +486,6 @@ What was refused: a difficulty badge and a per-row progress bar. The row's job i
 movement*; where the hero stands on it belongs to the detail screen, and a wall of unlit bars is
 exactly what the dedicated skill-tree screen was dropped for.
 
-### 4.5 The feeling feeds the prescription — the last link of a loop that is otherwise built
-
-*Freeletics* sells an adaptive coach and the mechanism under the marketing is mundane: the plan
-reacts to what the athlete reports. Bati collects that report already — "Comment c'était ? ·
-Trop facile · Parfait · Trop dur" ships on `components/session/VictoryView.tsx`, persists through
-`updateSessionFeedback`, and `analyzeDifficultyProgression` turns the last five sessions into
-increase / maintain / decrease.
-
-The link that is missing is the last one. `suggestDifficultyFromSessions` — what
-`app/(tabs)/adventures/[id].tsx` actually calls to pick a level — reads `sessions.userLevel`, the
-difficulty the hero *chose*. Not the feeling. So answering "too easy" five times raises nothing
-by itself; it renders a recommendation card in the Journal and waits for the hero to act on it.
-Two functions in one file, one of them already computing the right answer.
-
-**This is not the per-set RIR capture that §7 closed**, and it never becomes it: the question
-already exists and asks once, after the effort. If it ever grows a per-set form, the closed
-decision applies again.
-
 ### 4.6–4.8 The other refontes
 
 **Boss battle** (4.6) is the payoff the whole RPG layer is promising — and the scan changed what
@@ -710,7 +692,7 @@ one arrives naked, and 27 authored quests behind two filters answer the same nee
 
 Freeletics' adaptive coach went the same way: "ask the athlete how it went" is on the victory
 screen already, in both locales, feeding `analyzeDifficultyProgression`. Only the last hop was
-missing (4.5).
+missing, and 4.5 shipped it — the feeling now moves an adventure's level one rung.
 
 **Three of the first four candidates from this scan turned out to be already built.** That is the
 finding, not an embarrassment: this app's problem is not a thin feature set, it is that
@@ -883,8 +865,8 @@ Each of these was proposed, considered, and closed. They are here so they stop c
   form did not. Twelve extra interactions a session, in an app that spent a whole roadmap
   removing friction. One optional field on an exercise's last set is the door if the data is
   ever genuinely wanted. **The session feeling on the victory screen is not that door** — it asks
-  once, after the effort, and it shipped. If it ever grows a per-set form, this decision applies
-  again. See §4.5 for the half of that loop still missing.
+  once, after the effort, and it shipped — and since 4.5 its answer moves the level an adventure
+  proposes. If it ever grows a per-set form, this decision applies again.
 - **Finer muscle taxonomy.** `muscleToResource` maps muscles 1:1 onto the village's six
   resources, so every muscle added costs a resource, a building, a sprite and a colour. The rules
   that wanted finer muscles actually wanted **movement patterns** — `exercises.pattern`, added in

--- a/locales/en.json
+++ b/locales/en.json
@@ -285,6 +285,7 @@
     "details_title": "Adventure",
     "not_found": "Adventure not found",
     "invalid_id": "Invalid adventure",
+    "level_from_feedback": "Adjusted from your feedback",
     "load_error": "Failed to load adventure",
     "start_error": "Could not start the adventure",
     "reward_xp_per_step": "up to +{{count}} XP per step",

--- a/locales/en.json
+++ b/locales/en.json
@@ -285,7 +285,7 @@
     "details_title": "Adventure",
     "not_found": "Adventure not found",
     "invalid_id": "Invalid adventure",
-    "level_from_feedback": "Adjusted from your feedback",
+    "level_from_feedback": "From your feedback",
     "load_error": "Failed to load adventure",
     "start_error": "Could not start the adventure",
     "reward_xp_per_step": "up to +{{count}} XP per step",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -27,7 +27,7 @@
     "kind_boss": "BOSS",
     "kind_event": "ÉVÉNEMENT",
     "kind_route": "ROUTE",
-    "level_from_feedback": "Ajusté d’après tes retours",
+    "level_from_feedback": "D’après tes retours",
     "load_error": "Échec du chargement de l’aventure",
     "not_found": "Aventure introuvable",
     "reward_xp_per_step": "jusqu'à +{{count}} XP par étape",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -27,6 +27,7 @@
     "kind_boss": "BOSS",
     "kind_event": "ÉVÉNEMENT",
     "kind_route": "ROUTE",
+    "level_from_feedback": "Ajusté d’après tes retours",
     "load_error": "Échec du chargement de l’aventure",
     "not_found": "Aventure introuvable",
     "reward_xp_per_step": "jusqu'à +{{count}} XP par étape",


### PR DESCRIPTION
Roadmap [§4.5](docs/planning/roadmap.md), P1. La boucle était construite aux trois quarts : la question de fin de séance écrit `easy` / `good` / `hard`, `analyzeDifficultyProgression` en tire un verdict, le Journal l'affiche — mais rien n'agissait dessus.

## Ce qui manquait

`suggestDifficultyFromSessions`, la fonction qui choisit réellement le niveau d'une aventure, ne lisait que `userLevel` : la difficulté *choisie*. Répondre « trop facile » cinq fois ne changeait rien, et l'écran n'offre aucun sélecteur pour agir sur le conseil affiché ailleurs.

## Un verrou trouvé en traçant

`getRecentSessionHistory` **ne rendait pas les séances récentes.** Elle triait par `performedAt` ascendant puis appliquait `.limit(n)` : la limite mordait le mauvais bout et la requête rendait les n séances *les plus anciennes*. Passé la n-ième, la suggestion, la carte de progression du Journal et le graphe étaient gelés sur le début de l'historique, définitivement. `getQuestSessionHistory` avait le même défaut.

Le test qui aurait dû l'attraper banquait trois séances, en demandait deux et n'assertait que `length === 2` — il passait dans les deux sens.

## Les trois commits

| | |
|---|---|
| `5ebfeccf` | `fix(db)` — tri descendant puis `reverse()`, le contrat ascendant est préservé pour le graphe et les `.slice(-n)` en aval. Les tests assertent maintenant *lesquelles* séances reviennent. |
| `9000ca05` | `feat(progression)` — la fonction rend `{ level, adjusted }` : le niveau tiré des dix derniers choix, décalé d'un cran par le ressenti des cinq dernières séances. `startAdventureRun` n'épingle plus la campagne, donc chaque étape relit la suggestion. |
| `5285a491` | `fix(adventures)` — la légende sortait de l'écran par-dessus le titre ; l'idiome de l'en-tête des exercices (`flex` + `minW={0}`, seul le titre cède) répare la ligne. |

## Garde-fous

- Il faut **3 séances sur 5** qui disent la même chose : un mauvais soir ne bouge rien.
- `feedback: null` compte comme `good`, donc **un héros qui ne répond jamais n'est jamais déplacé** — aucun changement de comportement pour lui.
- `adjusted` dit si le niveau a *bougé*, pas s'il y a eu un verdict : « trop facile » à `hard` ne mène nulle part et la légende ne s'affiche pas.
- Un run épinglé avant ce PR finit sa campagne au niveau où il a commencé, sans légende.
- Les **quêtes** ne sont pas touchées : elles gardent le niveau que le héros leur règle.

Un `ponytail:` marque le plafond connu : la fenêtre de ressenti chevauche un décalage, donc trois « trop facile » dits à `medium` poussent encore une fois après le passage à `hard`. Symétrique, converge en trois retours dans chaque sens.

## Vérification

`npm run check` et `npm test` verts — 961 tests, seuils de couverture tenus.

Vérifié sur un Fairphone 6, trois scénarios, base dev restaurée octet pour octet ensuite :

| Ressenti récent | Tag affiché | Légende |
|---|---|---|
| « Trop facile » ×5 | **Difficile** | ✅ D'après tes retours |
| « Trop dur » ×5 | **Facile** | ✅ D'après tes retours |
| Aucun | **Moyen** | — |

Les 12 séances plus anciennes portaient à chaque fois le ressenti **inverse** des récentes, donc l'écran prouve aussi la correction d'ordre : le code d'avant aurait affiché l'étiquette opposée à chaque ligne.

Le débordement de la légende n'était visible sur aucun test — c'est le device qui l'a trouvé. L'anglais n'a pas été vu à l'écran : la chaîne est plus courte que la française qui tient déjà, et le test de rendu vérifie sa présence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)