### PR TITLE
A session gets a name that is not a counter

### DIFF
--- a/__tests__/db-migrate.test.ts
+++ b/__tests__/db-migrate.test.ts
@@ -224,11 +224,16 @@ describe("db/migrate", () => {
   });
 
   it("migrates even when the backup fails, because a backup is not a gate", async () => {
-    // `backupBeforeMigrations` promises never to throw, and this is the test that keeps the
-    // promise cheap to rely on: if it ever breaks it, the app still starts.
+    // `backupBeforeMigrations` promises never to throw, and this is the test that stops the app
+    // depending on it keeping the promise: a card pulled mid-launch must cost the backup, not
+    // the launch. Asserted on the schema, not on "it didn't reject" — the question is whether
+    // the migrations *ran*.
     backupBeforeMigrations.mockImplementation(() => Promise.reject(new Error("card removed")));
 
-    await expect(freshRunner(sqlite).ensureMigrations()).rejects.toThrow("card removed");
+    await freshRunner(sqlite).ensureMigrations();
+
+    expect(backupBeforeMigrations).toHaveBeenCalledTimes(1);
+    expect(tables()).toContain("user_preferences");
   });
 
   it("memoises success, so two callers in one process migrate once", async () => {

--- a/__tests__/db-migrate.test.ts
+++ b/__tests__/db-migrate.test.ts
@@ -1,5 +1,7 @@
 import Database from "better-sqlite3";
 
+import { UUID_V7_RE } from "../db/uuid";
+
 // The riskiest code in the app and, until now, the least covered: 2 lines of 80. It runs on every
 // cold start of both entry points (the React tree and the headless widget task), and its failure
 // mode is not a crash — it is a stranger's year of training disappearing on an update.
@@ -118,6 +120,83 @@ describe("db/migrate", () => {
       .prepare("SELECT value FROM user_preferences WHERE key = 'language'")
       .get() as { value: string } | undefined;
     expect(kept?.value).toBe("fr");
+  });
+
+  it("0038 names every session already in the journal", async () => {
+    // The backfill is a one-shot: it runs once, on a real hero's history, and there is no second
+    // chance to notice it wrote nonsense. So it is driven here the way a device meets it — a
+    // journal written under the old schema, then the migration.
+    process.env.EXPO_PUBLIC_MIGRATION_MAX_IDX = "37";
+    await freshRunner(sqlite).ensureMigrations();
+
+    // One session either side of a DST switch. Not pinned to a zone: `process.env.TZ` set from a
+    // test never reaches SQLite's `localtime`, because jest hands the sandbox a copy of the
+    // environment and libc reads the real one. So the offsets are asserted against `Date` for the
+    // same instants instead — which is the invariant that matters, the column having two writers
+    // (this SQL and the schema's `$defaultFn`) that have to agree.
+    const winter = 1_700_000_000; // 2023-11-14, CET where this is written
+    const summer = 1_718_083_200; // 2024-06-11, CEST
+    // Distinct instants, deliberately: v7 orders by the millisecond and leaves ties to the random
+    // tail, so two sessions logged in the same second have no defined order and asserting one
+    // would be asserting a coin toss.
+    const log = sqlite.prepare("INSERT INTO completed_sessions (performedAt) VALUES (?)");
+    log.run(winter);
+    log.run(summer);
+    log.run(summer + 3600);
+
+    process.env.EXPO_PUBLIC_MIGRATION_MAX_IDX = undefined;
+    delete process.env.EXPO_PUBLIC_MIGRATION_MAX_IDX;
+    await freshRunner(sqlite).ensureMigrations();
+
+    const rows = sqlite
+      .prepare("SELECT id, uuid, originDevice, tzOffsetMin FROM completed_sessions ORDER BY id")
+      .all() as { id: number; uuid: string; originDevice: string | null; tzOffsetMin: number }[];
+
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.uuid).toMatch(UUID_V7_RE);
+      // Nothing in this database ever recorded which device wrote a row before today, and
+      // inventing one would be worse than admitting it.
+      expect(row.originDevice).toBeNull();
+    }
+    expect(new Set(rows.map((r) => r.uuid)).size).toBe(3);
+
+    // The whole point of v7 over v4: sorting the names sorts the history.
+    const byUuid = sqlite.prepare("SELECT id FROM completed_sessions ORDER BY uuid").all() as {
+      id: number;
+    }[];
+    const byTime = sqlite
+      .prepare("SELECT id FROM completed_sessions ORDER BY performedAt, id")
+      .all() as { id: number }[];
+    expect(byUuid).toEqual(byTime);
+
+    // Positive east of Greenwich — the opposite sign to getTimezoneOffset(), which is the
+    // convention db/schema.ts writes down, and the one thing here a phone cannot correct later.
+    const jsWinter = 0 - new Date(winter * 1000).getTimezoneOffset();
+    const jsSummer = 0 - new Date(summer * 1000).getTimezoneOffset();
+    expect(rows[0]?.tzOffsetMin).toBe(jsWinter);
+    expect(rows[1]?.tzOffsetMin).toBe(jsSummer);
+
+    // Read per row, not once for "now": in a zone with summer time the two rows must differ, and
+    // by the same amount `Date` says. On a runner in UTC — which CI is — there is no difference
+    // to see and this proves nothing, so it is stated rather than asserted into a false green.
+    if (jsWinter !== jsSummer) {
+      expect((rows[1]?.tzOffsetMin ?? 0) - (rows[0]?.tzOffsetMin ?? 0)).toBe(jsSummer - jsWinter);
+    }
+
+    // A UNIQUE index the backfill could violate would fail every launch forever, which is the
+    // failure mode 0035 was written about.
+    expect(() =>
+      sqlite
+        .prepare("INSERT INTO completed_sessions (performedAt, uuid) VALUES (?, ?)")
+        .run(summer, rows[0]?.uuid),
+    ).toThrow(/UNIQUE/);
+    // …but several NULLs are fine, which is what keeps the dev seeder's raw SQL legal.
+    const seeded = sqlite.prepare("INSERT INTO completed_sessions (performedAt) VALUES (?)");
+    expect(() => {
+      seeded.run(summer);
+      seeded.run(summer);
+    }).not.toThrow();
   });
 
   it("backs up before the runner touches the schema, and not at all when nothing is pending", async () => {

--- a/__tests__/db-uuid.test.ts
+++ b/__tests__/db-uuid.test.ts
@@ -126,4 +126,39 @@ describe("createCompletedSession names its row", () => {
     // Positive east of Greenwich, the opposite sign to getTimezoneOffset().
     expect(first.tzOffsetMin).toBe(0 - new Date().getTimezoneOffset());
   });
+
+  // The two writers of these columns — this one and the 0038 backfill — have to mean the same
+  // thing, and only one of them can see `performedAt`. A session is saved after it is performed
+  // (stores/session.ts passes `startTime`), so a stamp read off the clock puts the save time in
+  // the new half of the journal and the session time in the migrated half: `ORDER BY uuid` stops
+  // being `ORDER BY performedAt` at the seam, and a summer save calls a winter workout CEST.
+  test("names a backdated session after when it happened, not when it was written", async () => {
+    const { createCompletedSession } =
+      require("../db/completed") as typeof import("../db/completed");
+
+    const exerciseId = (
+      t.sqlite.prepare("SELECT id FROM exercises LIMIT 1").get() as { id: number } | undefined
+    )?.id;
+    assert(exerciseId);
+
+    const performedAt = new Date("2024-01-15T10:00:00Z");
+    const id = await createCompletedSession({
+      performedAt,
+      exercises: [{ exerciseId, sortOrder: 0, result: { type: "reps", value: 10 } }],
+    });
+
+    const row = t.sqlite
+      .prepare("SELECT uuid, tzOffsetMin FROM completed_sessions WHERE id = ?")
+      .get(id) as { uuid: string; tzOffsetMin: number } | undefined;
+    assert(row);
+
+    // The first 48 bits are the millisecond, and it is the session's, to the millisecond.
+    const uuidMs = Number.parseInt(row.uuid.slice(0, 8) + row.uuid.slice(9, 13), 16);
+    expect(uuidMs).toBe(performedAt.getTime());
+
+    // Off that same date, so a zone with summer time reads 60 here and 120 in July. On a UTC
+    // runner both are 0 and this proves nothing beyond the uuid above — which is why the real
+    // assertion is the millisecond, and this one is written against `Date` rather than a literal.
+    expect(row.tzOffsetMin).toBe(0 - performedAt.getTimezoneOffset());
+  });
 });

--- a/__tests__/db-uuid.test.ts
+++ b/__tests__/db-uuid.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+
+import { UUID_V7_RE, uuidv7 } from "../db/uuid";
+import { clientMock, createTestDb } from "./helpers/testDb";
+
+describe("db/uuid", () => {
+  test("every draw is a well-formed v7", () => {
+    for (let i = 0; i < 100; i++) {
+      expect(uuidv7()).toMatch(UUID_V7_RE);
+    }
+  });
+
+  test("1000 draws are 1000 distinct names", () => {
+    const drawn = new Set(Array.from({ length: 1000 }, uuidv7));
+    expect(drawn.size).toBe(1000);
+  });
+
+  // The one property v7 buys over v4, and the one that breaks silently: sorting the strings has
+  // to sort the sessions. `db/exercises.ts` already leans on id order as a same-second
+  // tiebreaker, and a merged journal would lean on this instead.
+  test("sorts in time order", () => {
+    const now = jest.spyOn(Date, "now");
+
+    now.mockReturnValue(1_700_000_000_000);
+    const winter = uuidv7();
+    now.mockReturnValue(1_800_000_000_000);
+    const later = uuidv7();
+    // Same millisecond: the random tail decides, and neither is allowed to equal the other.
+    now.mockReturnValue(1_800_000_000_000);
+    const sameMs = uuidv7();
+
+    now.mockRestore();
+
+    expect([later, winter].sort()).toEqual([winter, later]);
+    expect(sameMs).not.toBe(later);
+    expect(later.slice(0, 13)).toBe(sameMs.slice(0, 13));
+  });
+
+  // A millisecond whose hex has a leading zero: `toString(16)` drops it, and an unpadded field
+  // would shift every character after it — silently, since the shape stays uuid-ish.
+  test("pads a timestamp with a leading zero", () => {
+    const now = jest.spyOn(Date, "now").mockReturnValue(0x0_00f_4240);
+    const padded = uuidv7();
+    now.mockRestore();
+
+    expect(padded).toMatch(UUID_V7_RE);
+    expect(padded.slice(0, 13)).toBe("0000000f-4240");
+  });
+});
+
+describe("db/preferences getDeviceId", () => {
+  const t = createTestDb();
+
+  beforeAll(() => {
+    jest.resetModules();
+    jest.doMock("../db/client", () => clientMock(t));
+  });
+
+  afterAll(() => {
+    t.close();
+  });
+
+  test("draws once, then answers from the database", async () => {
+    const prefs = require("../db/preferences") as typeof import("../db/preferences");
+
+    const first = await prefs.getDeviceId();
+    expect(first).toMatch(UUID_V7_RE);
+    expect(await prefs.getDeviceId()).toBe(first);
+
+    // Past the module memo: a fresh import must read the same name back, or every launch would
+    // claim to be a different device.
+    jest.resetModules();
+    jest.doMock("../db/client", () => clientMock(t));
+    const reloaded = require("../db/preferences") as typeof import("../db/preferences");
+    expect(await reloaded.getDeviceId()).toBe(first);
+  });
+});
+
+describe("createCompletedSession names its row", () => {
+  const t = createTestDb();
+
+  beforeAll(() => {
+    jest.resetModules();
+    jest.doMock("../db/client", () => clientMock(t));
+  });
+
+  afterAll(() => {
+    t.close();
+  });
+
+  test("stamps uuid, originDevice and tzOffsetMin", async () => {
+    const { createCompletedSession } =
+      require("../db/completed") as typeof import("../db/completed");
+    const { getDeviceId } = require("../db/preferences") as typeof import("../db/preferences");
+
+    const exerciseId = (
+      t.sqlite.prepare("SELECT id FROM exercises LIMIT 1").get() as { id: number } | undefined
+    )?.id;
+    assert(exerciseId);
+
+    const log = () =>
+      createCompletedSession({
+        exercises: [{ exerciseId, sortOrder: 0, result: { type: "reps", value: 10 } }],
+      });
+
+    const rows = [await log(), await log()].map((id) => {
+      const row = t.sqlite
+        .prepare("SELECT uuid, originDevice, tzOffsetMin FROM completed_sessions WHERE id = ?")
+        .get(id) as { uuid: string; originDevice: string; tzOffsetMin: number } | undefined;
+      assert(row);
+      return row;
+    });
+
+    const [first, second] = rows;
+    assert(first);
+    assert(second);
+
+    expect(first.uuid).toMatch(UUID_V7_RE);
+    expect(second.uuid).toMatch(UUID_V7_RE);
+    expect(first.uuid).not.toBe(second.uuid);
+
+    // One install, one origin — and it is the id the preferences table hands out.
+    expect(first.originDevice).toBe(await getDeviceId());
+    expect(second.originDevice).toBe(first.originDevice);
+
+    // Positive east of Greenwich, the opposite sign to getTimezoneOffset().
+    expect(first.tzOffsetMin).toBe(0 - new Date().getTimezoneOffset());
+  });
+});

--- a/db/completed.ts
+++ b/db/completed.ts
@@ -9,6 +9,7 @@ import {
   subWeeks,
 } from "date-fns";
 import { count, countDistinct, desc, eq, gte, sql, sum } from "drizzle-orm";
+import { reportError } from "@/src/reportError";
 import { db, schema, type TransactionTx, transactionOrFallback } from "./client";
 import { dayKey } from "./dates";
 import type { Exercise } from "./exercises";
@@ -22,6 +23,7 @@ import type {
   MuscleCode,
   QuestTargetType,
 } from "./schema";
+import { uuidv7 } from "./uuid";
 import { repEquivalentSql } from "./workUnits";
 
 const { completedExercises, completedQuest, exerciseMuscles, exercises, quests } = schema;
@@ -97,7 +99,20 @@ export async function createCompletedSession(input: CompletedSessionInput): Prom
   // writes `user_preferences` through `db`, and reaching for `db` from inside an open
   // `db.transaction` is the nesting `serializeOnDatabase` warns about (db/client.ts) — the inner
   // call would wait on the queue entry that is waiting on it.
-  const originDevice = await getDeviceId();
+  //
+  // And never a reason to fail: this is provenance nothing reads back, the column is nullable,
+  // and NULL already means "unknown" for every row logged before 0038. A workout the hero cannot
+  // re-enter must not be lost over the name of the phone that logged it.
+  const originDevice = await getDeviceId().catch((e) => {
+    reportError("session.originDevice", e);
+    return null;
+  });
+
+  // Resolved once, then it names the row: `uuid` and `tzOffsetMin` both describe *this instant*,
+  // and the schema's `$defaultFn` cannot see it — it would stamp the save instead. The session
+  // starts before it is saved (stores/session.ts passes `startTime`), so those are different
+  // clocks and different days, and 0038 backfilled the older half from `performedAt`.
+  const performedAt = input.performedAt ?? new Date();
 
   return transactionOrFallback(async (tx) => {
     const inserted = await tx
@@ -109,7 +124,9 @@ export async function createCompletedSession(input: CompletedSessionInput): Prom
         xpEarned: Math.max(0, Math.round(input.xpEarned ?? 0)),
         notes: input.notes ?? "",
         feedback: input.feedback ?? null,
-        performedAt: input.performedAt ?? new Date(),
+        performedAt,
+        uuid: uuidv7(performedAt.getTime()),
+        tzOffsetMin: 0 - performedAt.getTimezoneOffset(),
         originDevice,
       })
       .returning({ id: completedQuest.id });

--- a/db/completed.ts
+++ b/db/completed.ts
@@ -13,6 +13,7 @@ import { db, schema, type TransactionTx, transactionOrFallback } from "./client"
 import { dayKey } from "./dates";
 import type { Exercise } from "./exercises";
 import { isMuscleCode } from "./muscles";
+import { getDeviceId } from "./preferences";
 import { clearCached, setCached } from "./queryCache";
 import type {
   DifficultyCode,
@@ -89,9 +90,14 @@ function parseExerciseStyle(value: unknown): ExerciseStyle {
     : "strength";
 }
 
-// biome-ignore lint/suspicious/useAwait: async keeps the guard throw a rejected promise, not a sync throw
 export async function createCompletedSession(input: CompletedSessionInput): Promise<number> {
   if (input.exercises.length === 0) throw new Error("A completed session must have exercises");
+
+  // Read *before* the transaction, never inside it: on this install's first save `getDeviceId`
+  // writes `user_preferences` through `db`, and reaching for `db` from inside an open
+  // `db.transaction` is the nesting `serializeOnDatabase` warns about (db/client.ts) — the inner
+  // call would wait on the queue entry that is waiting on it.
+  const originDevice = await getDeviceId();
 
   return transactionOrFallback(async (tx) => {
     const inserted = await tx
@@ -104,6 +110,7 @@ export async function createCompletedSession(input: CompletedSessionInput): Prom
         notes: input.notes ?? "",
         feedback: input.feedback ?? null,
         performedAt: input.performedAt ?? new Date(),
+        originDevice,
       })
       .returning({ id: completedQuest.id });
 

--- a/db/migrate.ts
+++ b/db/migrate.ts
@@ -1,5 +1,6 @@
 import migrations from "../drizzle/migrations";
 import { backupBeforeMigrations } from "../src/autoBackup";
+import { reportError } from "../src/reportError";
 import { db } from "./client";
 import { sqlString } from "./sql";
 
@@ -241,10 +242,14 @@ export function ensureMigrations(): Promise<void> {
       // The one moment a backup is worth writing unattended, and the one moment this database
       // can be damaged in a way no undo covers. Gated on there being something to run so an
       // ordinary launch — every launch but the first after an update — pays one indexed read.
-      // It never throws: a folder that cannot be written is not a reason an app fails to start.
+      //
+      // Caught here rather than trusted: `backupBeforeMigrations` handles its own failures today,
+      // so this catch is unreachable — and that is exactly the point. A folder that cannot be
+      // written is not a reason an app fails to start, and without this line that promise is one
+      // future `throw` inside autoBackup away from being a launch that never completes.
       const lastAppliedAt = await readLastAppliedAt(client);
       if (config.journal.entries.some((entry) => isPending(entry, lastAppliedAt))) {
-        await backupBeforeMigrations();
+        await backupBeforeMigrations().catch((e) => reportError("backup.auto.gate", e));
       }
 
       await runMigrationsAsync(client, config, { debug: migrationsDebugEnabled() });

--- a/db/preferences.ts
+++ b/db/preferences.ts
@@ -47,7 +47,7 @@ export async function setPreference(
 }
 
 const DEVICE_ID_KEY = "deviceId";
-let deviceId: string | null = null;
+let deviceId: Promise<string> | null = null;
 
 /**
  * Which install is writing. Generated once, then it is this database's own name.
@@ -56,23 +56,32 @@ let deviceId: string | null = null;
  * came from. It is provenance, not identity — the identity is the session's `uuid` (db/uuid.ts),
  * which is unique whatever this returns.
  *
+ * The *promise* is memoised, not the name: two callers arriving before the first read returns
+ * would otherwise both find nothing, both draw, and both write — leaving the memo holding the
+ * loser of a race the database already decided. Same pattern as `ensureMigrations`, including
+ * dropping a rejection so the next caller retries rather than inheriting one bad read.
+ *
  * ponytail: the id lives *in* the database, so restoring a backup onto a second phone makes both
  *           claim the same origin. Harmless while nothing reads the column back; re-draw it on
  *           restore the day a merge actually attributes rows by it.
  */
-export async function getDeviceId(): Promise<string> {
+export function getDeviceId(): Promise<string> {
   if (deviceId !== null) return deviceId;
 
-  const existing = await getPreference(DEVICE_ID_KEY);
-  if (existing !== null) {
-    deviceId = existing;
-    return existing;
-  }
+  const promise = (async () => {
+    const existing = await getPreference(DEVICE_ID_KEY);
+    if (existing !== null) return existing;
 
-  const fresh = uuidv7();
-  await setPreference(DEVICE_ID_KEY, fresh);
-  deviceId = fresh;
-  return fresh;
+    const fresh = uuidv7();
+    await setPreference(DEVICE_ID_KEY, fresh);
+    return fresh;
+  })();
+
+  promise.catch(() => {
+    if (deviceId === promise) deviceId = null;
+  });
+  deviceId = promise;
+  return promise;
 }
 
 // Delete a preference

--- a/db/preferences.ts
+++ b/db/preferences.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db, schema, type TransactionTx } from "./client";
 import { isEquipmentCode } from "./equipment";
 import type { EquipmentCode } from "./schema";
+import { uuidv7 } from "./uuid";
 
 const { userPreferences } = schema;
 
@@ -43,6 +44,35 @@ export async function setPreference(
       target: userPreferences.key,
       set: { value, updatedAt: new Date() },
     });
+}
+
+const DEVICE_ID_KEY = "deviceId";
+let deviceId: string | null = null;
+
+/**
+ * Which install is writing. Generated once, then it is this database's own name.
+ *
+ * Stamped into `completed_sessions.originDevice` so a merged journal can say where a session
+ * came from. It is provenance, not identity — the identity is the session's `uuid` (db/uuid.ts),
+ * which is unique whatever this returns.
+ *
+ * ponytail: the id lives *in* the database, so restoring a backup onto a second phone makes both
+ *           claim the same origin. Harmless while nothing reads the column back; re-draw it on
+ *           restore the day a merge actually attributes rows by it.
+ */
+export async function getDeviceId(): Promise<string> {
+  if (deviceId !== null) return deviceId;
+
+  const existing = await getPreference(DEVICE_ID_KEY);
+  if (existing !== null) {
+    deviceId = existing;
+    return existing;
+  }
+
+  const fresh = uuidv7();
+  await setPreference(DEVICE_ID_KEY, fresh);
+  deviceId = fresh;
+  return fresh;
 }
 
 // Delete a preference

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { index, int, primaryKey, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { uuidv7 } from "./uuid";
 
 // ------------------------------------------------------------
 // Exercises catalogue
@@ -398,10 +399,29 @@ export const completedQuest = sqliteTable(
     performedAt: int({ mode: "timestamp" })
       .notNull()
       .$defaultFn(() => new Date()),
+
+    // The name this session keeps outside this database (0038). `id` is an AUTOINCREMENT
+    // counter, so two phones both call a session `143`; this is what a row-by-row merge would
+    // have to match on. Nullable only because `ADD COLUMN NOT NULL` wants a constant default —
+    // the `$defaultFn` is what actually guarantees it, on every Drizzle insert.
+    uuid: text().$defaultFn(uuidv7),
+
+    // Which install wrote the row — provenance, not identity (`db/preferences.ts`). Null on
+    // every session logged before 0038: nothing here recorded it.
+    originDevice: text(),
+
+    // Minutes east of Greenwich at the moment of the session: Paris in summer is **+120**, the
+    // opposite sign to `getTimezoneOffset()`. `dayKey()` buckets a session by the device's local
+    // day and never wrote down which day that was, so a session arriving from another device
+    // lands on the wrong calendar square with nothing able to notice.
+    // `0 - x`, not `-x`: negating a zero offset yields `-0`, which every later `Object.is` or
+    // strict comparison against a plain `0` answers false to.
+    tzOffsetMin: int().$defaultFn(() => 0 - new Date().getTimezoneOffset()),
   },
   (table) => ({
     performedAtIdx: index("completed_sessions_performed_at_idx").on(table.performedAt),
     questIdx: index("completed_sessions_quest_idx").on(table.questId),
+    uuidIdx: uniqueIndex("completed_sessions_uuid_unique").on(table.uuid),
   }),
 );
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -404,7 +404,11 @@ export const completedQuest = sqliteTable(
     // counter, so two phones both call a session `143`; this is what a row-by-row merge would
     // have to match on. Nullable only because `ADD COLUMN NOT NULL` wants a constant default —
     // the `$defaultFn` is what actually guarantees it, on every Drizzle insert.
-    uuid: text().$defaultFn(uuidv7),
+    //
+    // A net, not the writer: it cannot see `performedAt`, so it names the row after the moment
+    // it was saved. `createCompletedSession` overrides it with the moment it was *performed*,
+    // which is what the 0038 backfill wrote and what keeps `ORDER BY uuid` sorting the journal.
+    uuid: text().$defaultFn(() => uuidv7()),
 
     // Which install wrote the row — provenance, not identity (`db/preferences.ts`). Null on
     // every session logged before 0038: nothing here recorded it.
@@ -416,6 +420,10 @@ export const completedQuest = sqliteTable(
     // lands on the wrong calendar square with nothing able to notice.
     // `0 - x`, not `-x`: negating a zero offset yields `-0`, which every later `Object.is` or
     // strict comparison against a plain `0` answers false to.
+    //
+    // The same net as `uuid` above, with the same blind spot: today's offset, which is not the
+    // session's the moment a summer save describes a winter workout. `createCompletedSession`
+    // reads it off `performedAt`, like 0038 does.
     tzOffsetMin: int().$defaultFn(() => 0 - new Date().getTimezoneOffset()),
   },
   (table) => ({

--- a/db/uuid.ts
+++ b/db/uuid.ts
@@ -1,0 +1,44 @@
+/**
+ * A name for a session that survives leaving this database.
+ *
+ * `completed_sessions.id` is an `AUTOINCREMENT` counter, so it is a name only inside one SQLite
+ * file: two phones training the same week both write `id = 143`. Nothing breaks while a backup
+ * is a whole-file `VACUUM INTO` — restoring replaces — but the day two journals have to merge row
+ * by row there is no key that says "that session". This is that key.
+ *
+ * Version 7 rather than 4: the first 48 bits are the unix millisecond, so sorting the strings
+ * sorts the sessions. `drizzle/0038_sessions_name_themselves.sql` backfills existing rows from
+ * their own `performedAt` with the same layout, which is why the whole journal — before and after
+ * the migration — orders by `uuid` exactly as it orders by time.
+ *
+ * ponytail: `Math.random()` for the 74 random bits, not a CSPRNG. This is local collision
+ *           avoidance, not a secret: the ceiling is the day a uuid becomes something signed,
+ *           quoted back by a server, or guessed at — then `expo-crypto` and its native module.
+ *           Note that its `randomUUID()` is v4 and would cost the ordering above, so the swap is
+ *           the random half only.
+ */
+
+/** What a uuid looks like here. The one definition — `uuidv7()` and the 0038 backfill share it. */
+export const UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/** Random lowercase hex, `length` characters of it. */
+function randomHex(length: number): string {
+  let out = "";
+  while (out.length < length) {
+    // 8 hex chars per draw, zero-padded: `toString(16)` drops leading zeros, and a shorter
+    // chunk would quietly shift every field after it.
+    out += Math.floor(Math.random() * 0x1_0000_0000)
+      .toString(16)
+      .padStart(8, "0");
+  }
+  return out.slice(0, length);
+}
+
+export function uuidv7(): string {
+  // 48 bits of unix milliseconds, hex. Twelve characters until the year 10889.
+  const ts = Date.now().toString(16).padStart(12, "0");
+  // The variant nibble is 8, 9, a or b — 2 bits fixed, 2 random.
+  const variant = "89ab"[Math.floor(Math.random() * 4)];
+
+  return `${ts.slice(0, 8)}-${ts.slice(8, 12)}-7${randomHex(3)}-${variant}${randomHex(3)}-${randomHex(12)}`;
+}

--- a/db/uuid.ts
+++ b/db/uuid.ts
@@ -34,9 +34,16 @@ function randomHex(length: number): string {
   return out.slice(0, length);
 }
 
-export function uuidv7(): string {
+/**
+ * @param ms the instant this name stands for. Pass the session's `performedAt`, not the clock:
+ *   the 0038 backfill reads each row's own `performedAt`, so a writer that reads `Date.now()`
+ *   instead puts the save time in half the journal and the session time in the other half, and
+ *   `ORDER BY uuid` stops being `ORDER BY performedAt` at the seam. It defaults to now for a
+ *   name with no row behind it — `getDeviceId()`.
+ */
+export function uuidv7(ms: number = Date.now()): string {
   // 48 bits of unix milliseconds, hex. Twelve characters until the year 10889.
-  const ts = Date.now().toString(16).padStart(12, "0");
+  const ts = ms.toString(16).padStart(12, "0");
   // The variant nibble is 8, 9, a or b — 2 bits fixed, 2 random.
   const variant = "89ab"[Math.floor(Math.random() * 4)];
 

--- a/drizzle/0038_sessions_name_themselves.sql
+++ b/drizzle/0038_sessions_name_themselves.sql
@@ -1,0 +1,52 @@
+-- Une séance s'appelait « 143 », et son voisin aussi.
+--
+-- `completed_sessions.id` est un `INTEGER PRIMARY KEY AUTOINCREMENT` : un compteur, local au
+-- fichier SQLite. Deux appareils qui s'entraînent la même semaine écrivent tous les deux
+-- `id = 143`. Tant que la sauvegarde est un `VACUUM INTO` du fichier entier (db/backup.ts), ça ne
+-- se voit pas — restaurer, c'est remplacer. Le jour où deux journaux doivent fusionner ligne à
+-- ligne, il n'existe aucune clé pour dire « cette séance-là », et quatre tables pointent déjà vers
+-- cet id (completed_exercises, boss_damage_log, adventure_run_steps, resource_transactions).
+-- Le coût de cette fusion grandit à chaque semaine de journal ; on pose l'identité maintenant,
+-- pendant que le backfill est petit.
+--
+-- Trois colonnes, et rien qui change de comportement : `id` reste la clé primaire, reste ce que
+-- lisent les jointures, la route journal/[id] et le départage de db/exercises.ts. On pose
+-- l'identité, on ne la branche pas.
+--
+-- `uuid` est un v7 (db/uuid.ts) : ses 48 premiers bits sont la milliseconde unix, donc trier les
+-- chaînes trie les séances. Le backfill ci-dessous le reconstruit à partir du `performedAt` de
+-- chaque ligne, avec la même disposition — c'est ce qui fait qu'avant comme après cette
+-- migration, `ORDER BY uuid` vaut `ORDER BY performedAt`. `(random() & 3)` plutôt qu'un
+-- `abs(random()) % 4` : `abs()` déborde sur la seule valeur minimale de l'entier signé, et un
+-- masque de bits ne déborde jamais.
+--
+-- `tzOffsetMin` est positif à l'est de Greenwich — Paris en été vaut 120, soit l'inverse de
+-- `getTimezoneOffset()`. `dayKey()` calcule le jour en heure locale de l'appareil et n'a jamais
+-- écrit dans quel fuseau il l'a fait ; sans cette colonne, une séance rapatriée d'un autre
+-- appareil tombe sur le mauvais carré de calendrier sans que rien ne puisse le détecter.
+-- `datetime(..., 'localtime')` lit la base de fuseaux de l'appareil *à l'instant de la séance*,
+-- donc l'heure d'été de cette date-là, pas celle d'aujourd'hui.
+--
+-- `originDevice` n'est pas backfillé : rien dans cette base ne dit quel appareil a écrit une
+-- ligne d'avant aujourd'hui, et NULL veut dire « inconnu », ce qui est vrai.
+--
+-- Les colonnes restent nullables : `ADD COLUMN NOT NULL` exigerait une valeur par défaut
+-- constante, ce qu'un uuid n'est pas. La garantie est dans le type et le `$defaultFn` du schéma.
+-- L'index UNIQUE tolère plusieurs NULL en SQLite, donc une ligne écrite en SQL brut — le seeder
+-- de développement — ne peut pas transformer cet index en migration qui échoue pour toujours.
+-- C'est la leçon de 0035, appliquée à une autre table.
+
+ALTER TABLE `completed_sessions` ADD `uuid` text;--> statement-breakpoint
+ALTER TABLE `completed_sessions` ADD `originDevice` text;--> statement-breakpoint
+ALTER TABLE `completed_sessions` ADD `tzOffsetMin` integer;--> statement-breakpoint
+UPDATE `completed_sessions` SET
+  `uuid` =
+    substr(printf('%012x', `performedAt` * 1000), 1, 8) || '-' ||
+    substr(printf('%012x', `performedAt` * 1000), 9, 4) || '-7' ||
+    substr(lower(hex(randomblob(2))), 1, 3) || '-' ||
+    substr('89ab', (random() & 3) + 1, 1) || substr(lower(hex(randomblob(2))), 1, 3) || '-' ||
+    lower(hex(randomblob(6))),
+  `tzOffsetMin` =
+    (strftime('%s', datetime(`performedAt`, 'unixepoch', 'localtime')) - `performedAt`) / 60
+WHERE `performedAt` IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `completed_sessions_uuid_unique` ON `completed_sessions` (`uuid`);

--- a/drizzle/0038_sessions_name_themselves.sql
+++ b/drizzle/0038_sessions_name_themselves.sql
@@ -47,6 +47,5 @@ UPDATE `completed_sessions` SET
     substr('89ab', (random() & 3) + 1, 1) || substr(lower(hex(randomblob(2))), 1, 3) || '-' ||
     lower(hex(randomblob(6))),
   `tzOffsetMin` =
-    (strftime('%s', datetime(`performedAt`, 'unixepoch', 'localtime')) - `performedAt`) / 60
-WHERE `performedAt` IS NOT NULL;--> statement-breakpoint
+    (strftime('%s', datetime(`performedAt`, 'unixepoch', 'localtime')) - `performedAt`) / 60;--> statement-breakpoint
 CREATE UNIQUE INDEX `completed_sessions_uuid_unique` ON `completed_sessions` (`uuid`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1787119200000,
       "tag": "0037_xp_measures_effort",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1787122800000,
+      "tag": "0038_sessions_name_themselves",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -38,6 +38,7 @@ import m0034 from "./0034_quest_round_rest.sql";
 import m0035 from "./0035_hero_exercises.sql";
 import m0036 from "./0036_hero_names_are_theirs.sql";
 import m0037 from "./0037_xp_measures_effort.sql";
+import m0038 from "./0038_sessions_name_themselves.sql";
 import journal from "./meta/_journal.json";
 
 export default {
@@ -81,5 +82,6 @@ export default {
     m0035,
     m0036,
     m0037,
+    m0038,
   },
 };


### PR DESCRIPTION
`completed_sessions.id` is an `AUTOINCREMENT` integer, so it names a row only inside one SQLite file: two phones training the same week both write `id = 143`. Nothing breaks while a backup is a whole-file `VACUUM INTO` — restoring replaces — but the day two journals have to merge row by row, there is no key that says "that session". Four tables already point at that id (`completed_exercises`, `boss_damage_log`, `adventure_run_steps`, `resource_transactions`), so the cost of that merge grows with every week of journal. The identity goes in now, while the backfill is small.

**No behaviour change.** `id` stays the primary key and stays what the joins, the `journal/[id]` route and `db/exercises.ts`' same-second tiebreaker read. This lays the identity down; it does not wire anything to it.

## The three columns (`drizzle/0038_sessions_name_themselves.sql`)

| column | what it is |
|---|---|
| `uuid` | A v7: the first 48 bits are the unix millisecond, so sorting the strings sorts the sessions. |
| `originDevice` | Which install wrote the row. Provenance, not identity — the identity is the uuid, unique whatever this is. |
| `tzOffsetMin` | Minutes **east** of Greenwich at the moment of the session. Paris in summer is `+120`. |

The backfill rebuilds `uuid` for existing rows **from their own `performedAt`**, with the same layout — which is why `ORDER BY uuid` equals `ORDER BY performedAt` across the whole journal, before and after the migration. `tzOffsetMin` is read per row through `datetime(…, 'localtime')`, so it is the DST rules of *that date*, not today's.

`originDevice` is not backfilled: nothing in this database ever recorded it, and `NULL` means unknown, which is true.

### Three decisions worth the review

- **No new dependency.** `expo-crypto` would cost a native module built from source for F-Droid, and its `randomUUID()` is a **v4** — which would cost the ordering above. `Math.random()` is local collision avoidance, not a secret; the ceiling and the upgrade path are in a `ponytail:` note in `db/uuid.ts`.
- **The columns stay nullable.** `ADD COLUMN NOT NULL` wants a constant default, which a uuid is not — the schema's `$defaultFn` is the real guarantee. SQLite allows several `NULL`s under a `UNIQUE` index, so a row written in raw SQL (the dev seeder) can never turn that index into a migration that fails forever. That is 0035's lesson applied to another table.
- **The sign convention is written into the schema**, because a flipped sign between two devices is invisible to every tool we own. `dayKey()` has always bucketed a session by the device's local day without recording which day that was.

## Nothing is deleted

The migration never names `exercises`, contains no `DELETE` or `DROP`, and `SCHEMA_VERSION` stays at 3 — the only lever that orphans a database. The existing net still applies: the whole journal runs in one `BEGIN IMMEDIATE`, and `backupBeforeMigrations()` writes a snapshot before the first pending migration.

## Tests

`__tests__/db-uuid.test.ts` (new) and one case in `__tests__/db-migrate.test.ts`, which drives the **real** runner against a journal written under the old schema — the way a device meets it. The backfill is a one-shot on a real hero's history; there is no second chance to notice it wrote nonsense.

Four things those tests caught:

1. `getDeviceId()` was inside `transactionOrFallback` → a `db` write nested in an open transaction, which deadlocks on `serializeOnDatabase`'s queue. Hoisted out, with the reason in a comment.
2. Two sessions in the same second have **no** defined v7 order — the random tail decides. An ordering assertion over equal timestamps was a coin toss that passed locally and failed in UTC.
3. `-new Date().getTimezoneOffset()` yields `-0` in UTC, and `Object.is(-0, 0)` is false. The schema writes `0 - x`.
4. `process.env.TZ` set from a Jest test never reaches SQLite's `localtime` — Jest hands the sandbox a copy of the environment and libc reads the real one. The offsets are asserted against `Date` for the same instants instead, which is the invariant that matters: the column has two writers (this SQL and the schema's `$defaultFn`) and they have to agree. Verified green in UTC, Paris, Tokyo, New York, Kolkata and Auckland.

## Checks

- `biome check --error-on-warnings` clean, `tsc --noEmit` clean
- **968 tests pass**, coverage thresholds met (`db/uuid.ts` at 100%)
- `npm run deadcode` ok
- `npx expo export --platform android` builds, and the bundle contains the inlined `0038` SQL — the thing that breaks silently if `babel-plugin-inline-import` does not pick up a new `.sql` file
- `npx expo-doctor` fails on "16 packages out of date", confirmed pre-existing on `main` (verified by stashing this work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
