### PR TITLE
The warm-up asks what the hero owns, like everything else already did

### DIFF
--- a/__tests__/content-invariants.test.ts
+++ b/__tests__/content-invariants.test.ts
@@ -526,6 +526,49 @@ describe("content invariants", () => {
     expect(WARMUP_MOVEMENTS.filter((name) => !catalogue.has(name))).toEqual([]);
   });
 
+  /**
+   * The report: two days of "Traction scapulaire" in the warm-up of a hero who answered "sans
+   * matériel" in Settings. `buildWarmup` had never read that answer, so the pull pools offered
+   * Scapular Pull-Up and Inverted Row to everyone, and the quest gate that does read it
+   * (`getEligibleQuestIds`) only ever guarded the quest, never the four minutes before it.
+   *
+   * Driven from the catalogue rather than from a list of the two names known today: a movement
+   * added to a pool with a piece of kit behind it fails here, which is the only way this stays
+   * true.
+   */
+  test("a hero who owns nothing is never warmed up with equipment", async () => {
+    const { buildWarmup } = require("../constants/warmup") as typeof import("../constants/warmup");
+    const { listExercises, unavailableMovements } =
+      require("../db/exercises") as typeof import("../db/exercises");
+
+    t.sqlite
+      .prepare("INSERT OR REPLACE INTO user_preferences (key, value) VALUES (?, ?)")
+      .run("ownedEquipment", "[]");
+
+    const byName = new Map((await listExercises()).map((e) => [e.enName, e]));
+    const unavailable = await unavailableMovements();
+    // The guard is worth nothing if the hero could do everything anyway.
+    expect(unavailable.size).toBeGreaterThan(0);
+
+    const offenders = new Set<string>();
+    for (const quest of await loadQuests()) {
+      // Every rotation, not just the first: the offset is what decides which movement a phase
+      // gets, and the reported one only surfaced on some of them.
+      for (let sessionCount = 0; sessionCount < 12; sessionCount++) {
+        for (const stepName of buildWarmup(quest, sessionCount, unavailable)) {
+          const equipment = byName.get(stepName.exerciseName)?.equipment;
+          if (equipment !== undefined && equipment !== "none") {
+            offenders.add(`${stepName.exerciseName} (${equipment})`);
+          }
+        }
+      }
+    }
+
+    expect([...offenders]).toEqual([]);
+
+    t.sqlite.exec("DELETE FROM user_preferences");
+  });
+
   // A warm-up prepares; it does not train. Anything hard enough to cost the session is not a
   // warm-up movement, however well it fits the pattern the quest is about to load.
   test("no warm-up movement is a hard exercise", async () => {

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -42,6 +42,10 @@ jest.mock("@/db/completed", () => ({
 // behaviour — what it banks, commits and clears — is what these cases actually measure.
 jest.mock("@/db/exercises", () => ({
   checkForNewRungs: jest.fn().mockResolvedValue([]),
+  // The warm-up asks what the hero cannot do before it picks anything. A hero who owns
+  // everything is the shape these tests are written against; the filter itself is proved in
+  // warmup-build and against the real catalogue in content-invariants.
+  unavailableMovements: jest.fn().mockResolvedValue(new Set<string>()),
 }));
 jest.mock("@/db/oaths", () => ({
   checkOathFulfilled: jest.fn().mockResolvedValue(null),

--- a/__tests__/warmup-build.test.ts
+++ b/__tests__/warmup-build.test.ts
@@ -29,8 +29,11 @@ function quest(
 const longQuest = (patterns: (MovementPattern | null)[], archetype: QuestArchetype | null = null) =>
   quest(patterns, archetype, { rounds: 3, reps: 20, restSeconds: 45 });
 
-const names = (q: WarmupQuest, sessionCount = 0) =>
-  buildWarmup(q, sessionCount).map((s) => s.exerciseName);
+const names = (q: WarmupQuest, sessionCount = 0, unavailable?: ReadonlySet<string>) =>
+  buildWarmup(q, sessionCount, unavailable).map((s) => s.exerciseName);
+
+/** What a hero who answered "no equipment" cannot do: the two warm-up movements needing a bar. */
+const NO_BAR: ReadonlySet<string> = new Set(["Scapular Pull-Up", "Inverted Row"]);
 
 /** Held stretches belong after training, never before it. */
 const STATIC_HOLDS = ["Pigeon Pose", "Standing Forward Fold", "Warrior Pose", "Cobra Stretch"];
@@ -199,6 +202,35 @@ describe("buildWarmup", () => {
       expect(names(quest(["pull_vertical", "pull_horizontal", "core"]))).toContain(
         "Scapular Pull-Up",
       );
+    });
+
+    it("prepares the scapula without a bar when the hero has no bar", () => {
+      // Scapular Pull-Up and Inverted Row are the only two warm-up movements that need kit, and
+      // both sit in the pull pools. Excluded, the phase still fills: the pools carry a
+      // bodyweight answer behind each of them, which is why this is a filter and not a branch.
+      const built = names(quest(["pull_vertical", "pull_horizontal", "core"]), 0, NO_BAR);
+
+      expect(built).not.toContain("Scapular Pull-Up");
+      expect(built).not.toContain("Inverted Row");
+      expect(built.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("keeps offering them to a hero who owns the bar", () => {
+      expect(names(quest(["pull_vertical", "pull_horizontal", "core"]))).toContain(
+        "Scapular Pull-Up",
+      );
+    });
+
+    it("excludes an unavailable movement at every rotation, not just the first", () => {
+      for (let sessionCount = 0; sessionCount < 12; sessionCount++) {
+        const built = names(
+          quest(["pull_vertical", "pull_horizontal", "core"]),
+          sessionCount,
+          NO_BAR,
+        );
+        expect(built).not.toContain("Scapular Pull-Up");
+        expect(built).not.toContain("Inverted Row");
+      }
     });
 
     it("prepares several families when the session emphasises several", () => {

--- a/app/oath.tsx
+++ b/app/oath.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/components/common/Toast";
 import { ChevronLeft, ChevronRight, PenLine } from "@/components/icons";
 import { useOathText } from "@/components/oath/useOathText";
 import { getDateTimeFormat } from "@/constants/dateFormatters";
+import { canDo } from "@/db/equipment";
 import { type Exercise, listExercises, officialByName, pickableExercises } from "@/db/exercises";
 import {
   breakOath,
@@ -291,6 +292,7 @@ export default function OathScreen() {
 
   // Exercise presets need a real id; drop any whose seed exercise isn't loaded yet/present.
   const presetRows = useMemo(() => {
+    const owned = ownedEquipment === null ? null : new Set(ownedEquipment);
     const rows: { preset: OathPreset; label: string }[] = [];
     for (const p of OATH_PRESETS) {
       if (!oathNeedsExercise(p.metric)) {
@@ -307,13 +309,7 @@ export default function OathScreen() {
       const ex = presetExercise(p, exercises);
       // Drop presets whose exercise is absent, and any that need kit the hero does not own —
       // an oath you cannot move is worse than no oath at all.
-      if (
-        !ex ||
-        (ownedEquipment !== null &&
-          ex.equipment !== "none" &&
-          !ownedEquipment.includes(ex.equipment))
-      )
-        continue;
+      if (!ex || !canDo(ex.equipment, owned)) continue;
       // ponytail: `metric_exercise_pr` reads as "N reps in a row", true for every exercise_pr
       // preset except this one hold — L-Sit's PR is seconds. One special case rather than a
       // unit field on OathPreset, since it's the only hold-type preset today; give the field a

--- a/constants/warmup.ts
+++ b/constants/warmup.ts
@@ -242,8 +242,19 @@ function stepCount(quest: WarmupQuest): number {
  *
  * A quest whose exercises carry no pattern — user-authored content, where the column is nullable
  * on purpose — matches no family and falls through to the default pools.
+ *
+ * `unavailable` names the movements this hero cannot do, which today means the kit they said they
+ * do not own (`unavailableMovements()`). Two of the pull movements need a bar, and nothing here
+ * used to ask: a hero who answered "no equipment" in Settings was warmed up with scapular
+ * pull-ups anyway, session after session, while the quest gate that reads the same answer kept
+ * the quests themselves out of sight. It is a filter rather than a branch because every pool
+ * carries a bodyweight answer behind the one that needs kit, so the phase still fills.
  */
-export function buildWarmup(quest: WarmupQuest, sessionCount = 0): WarmupStep[] {
+export function buildWarmup(
+  quest: WarmupQuest,
+  sessionCount = 0,
+  unavailable: ReadonlySet<string> = new Set(),
+): WarmupStep[] {
   // An outing warms up by leaving. Eight indoor steps of star jumps and high knees in front of a
   // quest whose whole point is the door is the wrong protocol and the wrong story, and it was the
   // first thing every expedition showed.
@@ -271,7 +282,8 @@ export function buildWarmup(quest: WarmupQuest, sessionCount = 0): WarmupStep[] 
   // stepCount() only ever returns a key of PHASE_BUDGET; the index signature does not know it.
   const [raise, mobilise, activate, potentiate] = PHASE_BUDGET[stepCount(quest)] ?? [1, 1, 1, 1];
   const offset = Math.max(0, Math.trunc(sessionCount));
-  const used = new Set<string>();
+  // `take` skips whatever is already in here, so what the hero cannot do is simply pre-used.
+  const used = new Set<string>(unavailable);
 
   // Wrists go after activation and before the work-specific movement — closest to what is about
   // to load them. Outside the budget on purpose: it is a safety step, so a short quest shortens

--- a/db/equipment.ts
+++ b/db/equipment.ts
@@ -14,3 +14,19 @@ export const EQUIPMENT_LABELS: Record<EquipmentCode, { en: string; fr: string }>
 export function isEquipmentCode(value: unknown): value is EquipmentCode {
   return typeof value === "string" && (equipmentCodes as readonly string[]).includes(value);
 }
+
+/**
+ * Can the hero do a movement that needs this piece of kit?
+ *
+ * `owned` is `null` when the question has never been answered, and that means "show me
+ * everything": the default must not silently hide content from someone who has not been asked.
+ * An empty set is a real answer, bodyweight only, and `none` passes whatever the answer was.
+ *
+ * One function because the rule was written three times, and the third copy was the bug: quest
+ * eligibility filtered on it, the oath presets filtered on it, and the warm-up did not, so a
+ * hero with no bar was told to do scapular pull-ups for two days before the first session they
+ * could actually train.
+ */
+export function canDo(equipment: EquipmentCode, owned: ReadonlySet<EquipmentCode> | null): boolean {
+  return equipment === "none" || owned === null || owned.has(equipment);
+}

--- a/db/exercises.ts
+++ b/db/exercises.ts
@@ -1,8 +1,8 @@
 import { and, count, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { db, schema } from "./client";
-import { isEquipmentCode } from "./equipment";
+import { canDo, isEquipmentCode } from "./equipment";
 import { isMuscleCode } from "./muscles";
-import { getAllPreferences } from "./preferences";
+import { getAllPreferences, preferences } from "./preferences";
 import {
   ADMIN_CREATOR,
   type DifficultyCode,
@@ -165,6 +165,24 @@ export function listExercises(): Promise<Exercise[]> {
     });
   }
   return exercisesCache;
+}
+
+/**
+ * The names of the movements this hero cannot do, because they need kit that was not declared in
+ * Settings. Names rather than ids: the warm-up names its movements as strings and resolves them
+ * against the catalogue at render time, so this is the shape its caller needs.
+ *
+ * Hero-authored movements are in scope too. Someone who writes down a movement, tags it with a
+ * barbell and then says they own none has answered the question twice; the second answer wins.
+ */
+export async function unavailableMovements(): Promise<Set<string>> {
+  const [catalogue, ownedEquipment] = await Promise.all([
+    listExercises(),
+    preferences.getOwnedEquipment(),
+  ]);
+  const owned = ownedEquipment === null ? null : new Set(ownedEquipment);
+
+  return new Set(catalogue.filter((ex) => !canDo(ex.equipment, owned)).map((ex) => ex.enName));
 }
 
 export async function getExerciseById(id: number): Promise<Exercise | null> {

--- a/db/quests.ts
+++ b/db/quests.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq } from "drizzle-orm";
 import { db, schema } from "./client";
 import { dayKey } from "./dates";
+import { canDo } from "./equipment";
 import { currentRungFor, type Exercise, listExercises, type MovementRef } from "./exercises";
 import { isMuscleCode } from "./muscles";
 import { type ExerciseGhost, getExerciseHistory, ghostKey } from "./personalRecords";
@@ -868,19 +869,25 @@ export async function getEligibleQuestIds(): Promise<Set<number>> {
       .innerJoin(exercises, eq(exercises.id, questExercises.exerciseId)),
   ]);
 
-  const byQuest = new Map<number, { difficulties: DifficultyCode[]; equipment: Set<string> }>();
+  const byQuest = new Map<
+    number,
+    { difficulties: DifficultyCode[]; equipment: Set<EquipmentCode> }
+  >();
   for (const row of rows) {
-    const entry = byQuest.get(row.questId) ?? { difficulties: [], equipment: new Set<string>() };
+    const entry = byQuest.get(row.questId) ?? {
+      difficulties: [],
+      equipment: new Set<EquipmentCode>(),
+    };
     entry.difficulties.push(row.difficulty);
-    if (row.equipment !== "none") entry.equipment.add(row.equipment);
+    entry.equipment.add(row.equipment);
     byQuest.set(row.questId, entry);
   }
 
-  const owned = ownedEquipment === null ? null : new Set<string>(ownedEquipment);
+  const owned = ownedEquipment === null ? null : new Set<EquipmentCode>(ownedEquipment);
   const eligible = new Set<number>();
 
   for (const [questId, entry] of byQuest) {
-    const hasKit = owned === null || [...entry.equipment].every((code) => owned.has(code));
+    const hasKit = [...entry.equipment].every((code) => canDo(code, owned));
     const tooHard =
       trainingLevel === "beginner" && questTrainingLevel(entry.difficulties) === "advanced";
 

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -21,7 +21,12 @@ import {
   markSessionWithNewRecords,
 } from "@/db/completed";
 import { estimateQuestSeconds } from "@/db/estimate";
-import { checkForNewRungs, type Exercise, type VariationStep } from "@/db/exercises";
+import {
+  checkForNewRungs,
+  type Exercise,
+  unavailableMovements,
+  type VariationStep,
+} from "@/db/exercises";
 import { isMountedOuting, isOutingSession } from "@/db/expeditions";
 import { deletePoints } from "@/db/gps";
 import { checkOathFulfilled, OATH_XP_BONUS, type OathProgress } from "@/db/oaths";
@@ -896,7 +901,11 @@ export const useSessionStore = create<SessionState>()(
       // Rotates which movement fills each phase, so the warm-up is not the same four every
       // session. A failed read costs variety, never the warm-up itself.
       const { totalSessions } = await getSessionAggregates().catch(() => ({ totalSessions: 0 }));
-      const warmupSequence = buildWarmup(quest, totalSessions);
+      // What the hero said they do not own. A failed read costs the filter, never the warm-up:
+      // an unfiltered warm-up is the old behaviour, and no warm-up is a worse answer than a
+      // scapular pull-up someone skips.
+      const unavailable = await unavailableMovements().catch(() => new Set<string>());
+      const warmupSequence = buildWarmup(quest, totalSessions, unavailable);
       const warmupFirst = warmupEnabled && warmupSequence.length > 0;
 
       const opening = openingState(quest, warmupFirst, warmupSequence);


### PR DESCRIPTION
## The report

> Cela fait deux jours que dans mon échauffement il me propose des "Traction scapulaire" alors que j'ai demandé "sans matériel" dans les paramètres.

Adam. Reproduced, and it is every session built on pulling, not two days of bad luck.

## What was wrong

`buildWarmup` had never read `ownedEquipment`. Two of the movements it can prescribe need a bar, **Scapular Pull-Up** and **Inverted Row**, and both sit in the pull pools (`ACTIVATE_BY_FAMILY.pull`, `POTENTIATE_BY_FAMILY.pull`), so a quest emphasising pulling proposed one whatever the hero owns.

What made it read as arbitrary from the outside is that the quest gate *does* read that preference, and always has. The quests needing a bar were correctly hidden, and then the four minutes in front of the session asked for one anyway.

## The fix

The rule was already written twice, in `getEligibleQuestIds` and in the oath presets, in the same three clauses both times. The warm-up was the third site and it was the one that did not have it.

- `canDo(equipment, owned)` in `db/equipment.ts` is the rule, once. All three sites read it. `null` still means the question was never answered and still shows everything; an empty set is a real answer.
- `unavailableMovements()` turns that into the names the hero cannot do, which is the shape the warm-up needs, since it names movements as strings and resolves them against the catalogue at render time.
- The filter is one line. `take` already skips anything in `used`, so what the hero cannot do is simply pre-used.

No phase can be emptied by it: every pool carries a bodyweight answer behind the one that needs kit. A failed read costs the filter, never the warm-up.

## Tests, written first

All three red before the fix, green after.

| Test | What it holds |
|---|---|
| `content-invariants` | Builds the exclusion the way the app builds it, sweeps every seeded quest across twelve rotations, and reads equipment **off the catalogue**. A movement added to a pool with kit behind it fails here. |
| `warmup-build` ×2 | The pull phase still fills without a bar, and the exclusion holds at every rotation rather than only the first. |

The invariant is deliberately not written against a list of the two names that need a bar today, which is the version that would have rotted.

`npm run check`, `npm run deadcode`, `npm test` on Node 24 (1504 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFt3phuFjAwmrkqN4QMjtE