### PR TITLE
The warm-up counts its seconds out loud, like every other timed screen

### DIFF
--- a/__tests__/warmup-view.test.tsx
+++ b/__tests__/warmup-view.test.tsx
@@ -5,6 +5,7 @@ import { TamaguiProvider } from "tamagui";
 import { WarmupView } from "@/components/session/WarmupView";
 import { WARMUP_SEQUENCE } from "@/constants/warmup";
 import { listExercises } from "@/db/exercises";
+import { playCue } from "@/src/sounds";
 import { useSessionStore } from "@/stores/session";
 import config from "@/tamagui.config";
 
@@ -35,6 +36,7 @@ jest.mock("@/db/preferences", () => ({
 jest.mock("@/db", () => ({ preferences: {} }));
 jest.mock("@/i18n", () => ({ i18n: { changeLanguage: jest.fn() } }));
 jest.mock("@/src/i18n/deviceLanguage", () => ({ getDevicePreferredAppLanguage: () => "en" }));
+jest.mock("@/src/sounds", () => ({ playCue: jest.fn(), warm: jest.fn() }));
 
 async function mountWarmup() {
   let result!: ReturnType<typeof render>;
@@ -87,6 +89,45 @@ describe("WarmupView", () => {
     });
 
     expect(useSessionStore.getState().warmupIndex).toBe(1);
+  });
+
+  /**
+   * The report: no beep on any warm-up movement, only on the last one. The beep heard at the end
+   * is the pre-start countdown that follows the warm-up, not the last movement announcing itself:
+   * this screen was the one timed view that never called `useCountdownCues`, so all four of its
+   * countdowns ran silent and the first sound of a session came after the warm-up was over.
+   *
+   * Driven across two movements rather than one, because "only the last one" is a claim about the
+   * ones before it.
+   */
+  it("counts the last three seconds of every movement, not just the one before the session", async () => {
+    const mockedPlayCue = playCue as jest.MockedFunction<typeof playCue>;
+    mockedPlayCue.mockClear();
+
+    await mountWarmup();
+
+    // One second per act(): React batches inside a single act, so a jump would render once with
+    // the final value and only the zero would ever be observable. See the same note in
+    // __tests__/rest-view.test.tsx.
+    const stepSeconds = WARMUP_SEQUENCE[0].seconds;
+    for (let second = 0; second < stepSeconds; second++) {
+      await act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    }
+
+    expect(mockedPlayCue.mock.calls.map(([cue]) => cue)).toEqual(["tick", "tick", "tick", "go"]);
+    // The second movement is a countdown too, and it was the silent case.
+    expect(useSessionStore.getState().warmupIndex).toBe(1);
+
+    mockedPlayCue.mockClear();
+    for (let second = 0; second < stepSeconds; second++) {
+      await act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+    }
+
+    expect(mockedPlayCue.mock.calls.map(([cue]) => cue)).toEqual(["tick", "tick", "tick", "go"]);
   });
 
   it("shows the movement's description, so the hero knows what to do", async () => {

--- a/components/session/WarmupView.tsx
+++ b/components/session/WarmupView.tsx
@@ -7,6 +7,7 @@ import { Button, H1, H3, Progress, Text, XStack, YStack } from "tamagui";
 import { Pause, SkipBack, SkipForward } from "@/components/icons";
 import { getExerciseAsset, getExerciseThumb } from "@/constants/assetMap";
 import { type Exercise, listExercises, officialByName } from "@/db/exercises";
+import { useCountdownCues } from "@/hooks/useCountdownCues";
 import { useHaptics } from "@/hooks/useHaptics";
 import { formatTime, useSessionTimer } from "@/hooks/useSessionTimer";
 import { localizedName } from "@/src/i18n/localized";
@@ -44,6 +45,12 @@ export function WarmupView() {
   const skipWarmup = useSessionStore((s) => s.skipWarmup);
   const pauseSession = useSessionStore((s) => s.pauseSession);
   const { remainingSeconds, progress } = useSessionTimer();
+  // Declared above the auto-advance effect below, the same way `RestView` does it: on the render
+  // where a movement hits zero, this one runs first, so the "go" starts before `nextWarmupStep()`
+  // resets the timer under it. Without it this screen was the one timed view that never counted,
+  // so all four of its countdowns ran silent and the first sound of a session was the pre-start
+  // countdown that follows the warm-up, which reads as "only the last movement beeps".
+  useCountdownCues(remainingSeconds);
 
   const [catalogue, setCatalogue] = useState<Exercise[]>([]);
 


### PR DESCRIPTION
## The report

> P1 Pas de bip pendant le warm-up sauf sur le dernier. Le son de fin d'exercice ne se déclenche pas sur les mouvements du warm-up, uniquement sur le dernier.
>
> en fait je me suis rendu compte que sur certain compte à rebours j'avais pas le bip final

Both sentences are the same bug, and the "sauf sur le dernier" part is a misreading the screen invited: **nothing beeps at the end of the last movement either.** What you hear there is the pre-start countdown that follows the warm-up. The first sound of a session arrived after the warm-up was over.

## What was wrong

`WarmupView` was the one timed view that never called `useCountdownCues`. One missing line, four silent countdowns.

I checked the other three rather than assume, because you flagged a missing *final* beep specifically:

| View | Cues | Evidence |
|---|---|---|
| `RestView` | `tick tick tick go` | existing wiring test |
| `ActiveExerciseView` | ticks on a timed hold | existing wiring test |
| `CountdownView` | `tick tick tick go` | checked on this branch |
| `WarmupView` | **nothing** | `[]` against four expected |

So "certains comptes à rebours sans bip final" is the four warm-up movements. No other countdown loses its zero.

## The fix

The one line the other three already have, placed above the auto-advance effect for the reason `RestView` documents: on the render where a movement hits zero, the cue effect runs first, so the "go" starts before `nextWarmupStep()` resets the timer under it.

## The test

Red at `[]` before the fix. It drives **two** movements, because "only the last one" is a claim about the ones before it, and the hook's `previousRef` lives across steps since the view stays mounted.

## One consequence, stated rather than hidden

The last movement now ends on its "go" and the pre-start countdown opens on "3" right behind it. That is already what you hear when you skip the warm-up by hand, and each countdown announcing itself is the rule everywhere else in the session. Say the word if you would rather the last movement stayed quiet.

`npm run check`, `npm run deadcode`, `npm test` on Node 24 (1505 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFt3phuFjAwmrkqN4QMjtE