### PR TITLE
Reading what a movement is stops the clock

### DIFF
--- a/__tests__/session-instructions-modal.test.tsx
+++ b/__tests__/session-instructions-modal.test.tsx
@@ -11,7 +11,8 @@ import config from "@/tamagui.config";
 /**
  * The paused screen was the only place the movement was ever *drawn* and explained, which meant
  * the answer to "what is a dead bug?" cost a pause. The running screen now opens the same block
- * as a modal, from the art or from the row that names it.
+ * as a modal, from the art or from the row that names it — and stops the clock behind it, which
+ * is the half the modal did not have at first.
  *
  * Asserted on the text and the trigger, not on a state flag: the accordion this replaced showed
  * the description with no picture, and a test that only checked "some panel opened" would have
@@ -160,6 +161,57 @@ describe("the movement's instructions, mid-set", () => {
 
     expect(screen.getByTestId("session-instructions")).toBeTruthy();
     expect(screen.getByText(HOW_TO)).toBeTruthy();
+  });
+
+  /**
+   * Reading the movement used to cost whatever the clock ran while you read. The pause was
+   * already the one moment reading is free — it draws the same block — so the modal that made it
+   * reachable mid-set inherited the wrong half of that trade: the answer came without stopping
+   * the timer, and a hero who did not know the movement paid for finding out.
+   *
+   * Asserted on `prePauseStatus` as well as `status`: a pause that forgets what it interrupted
+   * resumes into "running", which would end a rest early and start a set nobody was ready for.
+   */
+  it("stops the clock while the movement is being read", async () => {
+    await mountRunning();
+
+    await act(async () => {
+      await fireEvent.press(screen.getByTestId("session-how-to"));
+    });
+
+    expect(useSessionStore.getState().status).toBe("paused");
+    expect(useSessionStore.getState().prePauseStatus).toBe("running");
+  });
+
+  it("gives the rest its own clock back too, not the set's", async () => {
+    await mountResting();
+
+    await act(async () => {
+      await fireEvent.press(screen.getByTestId("rest-up-next"));
+    });
+
+    expect(useSessionStore.getState().status).toBe("paused");
+    expect(useSessionStore.getState().prePauseStatus).toBe("resting");
+
+    await act(async () => {
+      await fireEvent.press(screen.getByTestId("session-instructions-close"));
+    });
+
+    expect(useSessionStore.getState().status).toBe("resting");
+  });
+
+  it("starts the clock again on the way out, so nothing has to be tapped twice", async () => {
+    await mountRunning();
+
+    await act(async () => {
+      await fireEvent.press(screen.getByTestId("session-how-to"));
+    });
+    await act(async () => {
+      await fireEvent.press(screen.getByTestId("session-instructions-close"));
+    });
+
+    expect(useSessionStore.getState().status).toBe("running");
+    expect(useSessionStore.getState().prePauseStatus).toBeNull();
   });
 
   it("closes again, so the set is never trapped behind it", async () => {

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -74,6 +74,7 @@ export function ActiveExerciseView() {
     };
   }, []);
   const pauseSession = useSessionStore((s) => s.pauseSession);
+  const resumeSession = useSessionStore((s) => s.resumeSession);
   const bossFight = useSessionStore((s) => s.bossFight);
   const lastDamageResult = useSessionStore((s) => s.lastDamageResult);
 
@@ -108,9 +109,24 @@ export function ActiveExerciseView() {
   const currentStep = currentRoundIndex * exercisesPerRound + currentExerciseIndex + 1;
   const progressPercent = (currentStep / totalSteps) * 100;
 
+  // Reading the movement stops the clock, and closing starts it again. The pause was already the
+  // one moment reading is free — it draws this same block — so a modal that answered "what is a
+  // dead bug?" without stopping the timer charged the hero for not knowing. Paired here rather
+  // than left to the paused screen's Resume: the hero asked to read, not to pause, so the way out
+  // of reading has to be the way back into the set.
+  //
+  // The paused overlay renders underneath, invisible: two stacked `$bgOverlay` at 0.92 leave it
+  // under a percent of a percent. Both calls are batched with the visibility flag, so no render
+  // ever shows one without the other.
   const handleShowHowTo = () => {
     selection();
+    pauseSession();
     setShowHowTo(true);
+  };
+
+  const handleCloseHowTo = () => {
+    resumeSession();
+    setShowHowTo(false);
   };
 
   const handleComplete = () => {
@@ -740,7 +756,7 @@ export function ActiveExerciseView() {
       <ExerciseInstructionsModal
         instruction={instruction}
         visible={showHowTo}
-        onClose={() => setShowHowTo(false)}
+        onClose={handleCloseHowTo}
       />
 
       <ExercisePickerSheet

--- a/components/session/ExerciseInstructions.tsx
+++ b/components/session/ExerciseInstructions.tsx
@@ -50,7 +50,13 @@ export function ExerciseInstructionsBody({
   );
 }
 
-/** The same block, opened from the running screen without stopping the set. */
+/**
+ * The same block, opened from the running screen and from the rest, over a session it stops.
+ *
+ * It did not stop it at first, which was the wrong half of the trade it was built to fix: the
+ * answer to "what is a dead bug?" arrived without a pause, and the clock ran while the hero read
+ * it. Both callers pause on the way in and resume on the way out.
+ */
 export function ExerciseInstructionsModal({
   instruction,
   visible,

--- a/components/session/PausedOverlay.tsx
+++ b/components/session/PausedOverlay.tsx
@@ -130,9 +130,9 @@ export function PausedOverlay() {
             </Paragraph>
           ) : null}
 
-          {/* The one moment reading is free. A hero who does not know what a dead bug is was
-              watching the clock run while they worked it out; here it is stopped. Same block the
-              running screen opens as a modal — see ExerciseInstructions.tsx. */}
+          {/* Reading is free here, and it is free from the running screen and the rest too: the
+              how-to modal pauses on the way in. This is what the hero lands on if they pause by
+              hand instead. Same block either way — see ExerciseInstructions.tsx. */}
           {instruction ? (
             <YStack pt="$2">
               <ExerciseInstructionsBody instruction={instruction} artSize={120} />

--- a/components/session/RestView.tsx
+++ b/components/session/RestView.tsx
@@ -47,6 +47,7 @@ export function RestView() {
   const lastSetSkipped = useSessionStore((s) => s.lastSetSkipped);
   const status = useSessionStore((s) => s.status);
   const pauseSession = useSessionStore((s) => s.pauseSession);
+  const resumeSession = useSessionStore((s) => s.resumeSession);
   const { remainingSeconds, progress } = useSessionTimer();
   // Declared above the auto-advance effect below on purpose: on the render where the rest hits
   // zero, this one runs first, so the "go" starts before skipRest() unmounts the screen.
@@ -98,6 +99,21 @@ export function RestView() {
   // Same rule as the running screen: during a fight the room's colour is the boss's, and it
   // darkens as the fight turns.
   const screenBg = getQuestColorTokensFromQuest(quest).bg;
+
+  // Reading the movement stops the clock, and closing starts it again. Same pairing as the
+  // running screen, and the same reason: the rest is the one moment reading was already free, so
+  // a modal that let the countdown run through it took that back. See ActiveExerciseView for the
+  // note on the paused overlay rendering underneath.
+  const handleShowHowTo = () => {
+    selection();
+    pauseSession();
+    setShowHowTo(true);
+  };
+
+  const handleCloseHowTo = () => {
+    resumeSession();
+    setShowHowTo(false);
+  };
 
   const handleSkipRest = () => {
     mediumImpact();
@@ -309,10 +325,7 @@ export function RestView() {
               borderWidth={1}
               borderColor="$borderStrong"
               gap="$2"
-              onPress={() => {
-                selection();
-                setShowHowTo(true);
-              }}
+              onPress={handleShowHowTo}
               pressStyle={{ opacity: 0.9 }}
               accessibilityRole="button"
               accessibilityLabel={t("session.how_to_do_it")}
@@ -377,7 +390,7 @@ export function RestView() {
       <ExerciseInstructionsModal
         instruction={instruction}
         visible={showHowTo}
-        onClose={() => setShowHowTo(false)}
+        onClose={handleCloseHowTo}
       />
     </YStack>
   );

--- a/docs/gameplay/session-flow.md
+++ b/docs/gameplay/session-flow.md
@@ -188,6 +188,11 @@ was there for it.
 
 **Purpose**: Take a break, options to continue or quit
 
+**Two doors into it.** The pause button, and opening a movement's how-to from the running screen
+or the rest: reading what a movement is stops the clock and closing it starts it again, so nobody
+pays for not knowing the movement. The mockup below predates both the sound toggle and the
+movement's art and description that the overlay now draws.
+
 ```
 ┌─────────────────────────────────────────────┐
 │                                             │


### PR DESCRIPTION
## The ask

> "La pause quand on ouvre la fiche du mouvement" — quand on ouvre le détail d'un exo la session doit se mettre en pause.

Done, on both doors: the running screen and the rest.

## Why it was the other way

The modal was built to fix the opposite complaint. The paused screen was the only place a movement was ever *drawn* and explained, so the answer to "what is a dead bug?" cost a pause, and `ExerciseInstructions.tsx` says as much: *"opened from the running screen without stopping the set."*

It took the wrong half of that trade. The answer arrived, but the clock ran through it, so a hero who did not know the movement paid for finding out in the one currency the screen deals in. Both halves now hold: reachable mid-set **and** free.

## Decisions worth naming

**Paired open/close, not "pause and let them tap Resume".** The hero asked to read, not to pause. The way out of reading is the way back into the set, so nothing is tapped twice.

**Nothing had to be suppressed or lifted into the store.** The paused overlay renders underneath the modal, and two stacked `$bgOverlay` at 0.92 leave it visible at under a percent of a percent. So `showHowTo` stays local to the two views, which is what kept this to two handlers instead of shared state.

**`prePauseStatus` carries the weight.** Pausing from a rest has to resume *as a rest*; a pause that forgets what it interrupted resumes into `running`, ending the rest early and starting a set nobody is ready for. The tests assert it, not just `status`.

## Tests

Three, two of them red before the change. The third (resume on close) was green beforehand and is kept as the pair to the second — on its own it proves nothing, together they pin the round trip.

Comments updated where they now say the opposite of the code: `ExerciseInstructions.tsx`, `PausedOverlay.tsx`, and the test's own header. `docs/gameplay/session-flow.md` gains a line naming the two doors into a pause, and says out loud that its ASCII mockup predates both the sound toggle and the instructions block the overlay already draws — I did not redraw it here.

`npm run check`, `npm run deadcode`, `npm test` on Node 24 (1508 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFt3phuFjAwmrkqN4QMjtE