### PR TITLE
fix(session): the victory screen drew the trophy's name, not the trophy

### DIFF
--- a/__tests__/session-rewards-achievement-icon.test.tsx
+++ b/__tests__/session-rewards-achievement-icon.test.tsx
@@ -1,0 +1,75 @@
+import { render } from "@testing-library/react-native";
+import { TamaguiProvider } from "tamagui";
+
+import { SessionRewards } from "@/components/session/SessionRewards";
+import { achievementDefinitions } from "@/db/achievements";
+import config from "@/tamagui.config";
+
+/**
+ * `05f0445e` turned `AchievementDefinition.icon` from an emoji glyph into an icon *code*
+ * ("Target", "crown") and routed the journal shelf and both village views through
+ * `AchievementIcon`. The victory screen was the fourth reader and nobody looked: it kept
+ * `<Text>{a.definition.icon}</Text>`, so the payoff card announced a new trophy and then drew
+ * the word "Target" underneath it.
+ *
+ * Asserts what the hero reads, not which component was mounted: no icon code ever reaches the
+ * screen as text.
+ */
+
+jest.mock("@/db/client", () => ({ db: {}, schema: {}, runMigrations: jest.fn() }));
+
+const codes = ["first_workout", "streak_3", "xp_100"] as const;
+const definitions = codes.map((code) => {
+  const def = achievementDefinitions.find((d) => d.code === code);
+  if (!def) throw new Error(`missing achievement definition: ${code}`);
+  return def;
+});
+
+const result = {
+  sessionId: 1,
+  xpEarned: 10,
+  dailyBonusXp: 0,
+  newRecords: [],
+  newRungs: [],
+  newAchievements: definitions.map((definition) => ({ code: definition.code, definition })),
+  fulfilledOath: null,
+  oathBonusXp: 0,
+  overshootXp: 0,
+  outing: null,
+  campaign: null,
+  levelUp: null,
+  tierUp: false,
+  villageGrowth: [],
+  heroXp: { before: 0, after: 10 },
+};
+
+type RewardsResult = React.ComponentProps<typeof SessionRewards>["result"];
+
+function renderRewards(language: "en" | "fr") {
+  return render(
+    <TamaguiProvider config={config} defaultTheme="dark">
+      <SessionRewards
+        result={result as unknown as RewardsResult}
+        language={language}
+        onViewVillage={jest.fn()}
+      />
+    </TamaguiProvider>,
+  );
+}
+
+describe("SessionRewards achievement icons", () => {
+  it.each(["en", "fr"] as const)("draws the glyph, never the icon code (%s)", async (language) => {
+    const { queryByText, getByText } = await renderRewards(language);
+
+    // The card really mounted, otherwise the absence below proves nothing.
+    for (const def of definitions) {
+      expect(getByText(language === "fr" ? def.frTitle : def.enTitle)).toBeTruthy();
+    }
+
+    // Every code in the table, not only the three shown: the fixture picks three, the shelf
+    // holds twenty-five, and a regression would break on whichever one it renders first.
+    for (const { icon } of achievementDefinitions) {
+      expect(queryByText(icon)).toBeNull();
+    }
+  });
+});

--- a/components/session/SessionRewards.tsx
+++ b/components/session/SessionRewards.tsx
@@ -2,6 +2,7 @@ import { Image } from "expo-image";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Text, XStack, YStack } from "tamagui";
+import { AchievementIcon } from "@/components/common/AchievementIcon";
 import { AppButton } from "@/components/common/AppButton";
 import { Card } from "@/components/common/Card";
 import { GameIcon } from "@/components/common/GameIcon";
@@ -291,7 +292,7 @@ export function SessionRewards({
                   items="center"
                   justify="center"
                 >
-                  <Text fontSize={26}>{a.definition.icon}</Text>
+                  <AchievementIcon icon={a.definition.icon} size={26} color="$text" />
                 </YStack>
                 <YStack flex={1}>
                   <Text fontWeight="700" fontSize={15} color="$text">


### PR DESCRIPTION
## The bug

`05f0445e` turned `AchievementDefinition.icon` from an emoji glyph into an icon *code*
(`"Target"`, `"crown"`, `"flame"`) and routed the journal shelf, the village shelf and the
village detail sheet through the new `AchievementIcon` resolver.

`SessionRewards` was the fourth reader and nobody looked. It kept:

```tsx
<Text fontSize={26}>{a.definition.icon}</Text>
```

So the one card whose job is to say "you won something" announced a new trophy and drew the
word **Target** underneath it.

## Audit

Every surface that renders a trophy was checked, not only the one reported:

| Surface | Renders through | Status |
| --- | --- | --- |
| Journal, Succès card | `AchievementIcon` | fine |
| Village, trophy rack | `AchievementIcon` | fine |
| Village, detail sheet | `AchievementIcon` | fine |
| **Victory, rewards reveal** | raw `<Text>` | **broken, fixed here** |

The icon table itself is sound: all 23 distinct codes resolve, either as a `GameIconName` or
through `LUCIDE_ACHIEVEMENT_ICONS`, and every lucide name is exported from `components/icons.ts`.
No other component in `app/` or `components/` renders an `icon` or `emoji` field as text.

## The fix

One line, the resolver every other trophy view already uses.

## The guard

`__tests__/session-rewards-achievement-icon.test.tsx` mounts the reveal with three unlocked
achievements and asserts what the hero reads: the three titles are present (so the card really
mounted and the absence below proves something), and no code from the whole icon table reaches
the screen as text, in either language. Verified failing on the old line before the swap.

## Checks

- `npm run check` green
- `nvm exec 24 npm test` green, 1564 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re3AdhNPmNAd6XQkrY32Tq