### PR TITLE
Four short fixes the design audits found, from the deaf session detail to the dropped XP series

### DIFF
--- a/__tests__/db-completed.test.ts
+++ b/__tests__/db-completed.test.ts
@@ -98,6 +98,33 @@ describe("db/completed", () => {
     expect(row.movingSeconds).toBe(2_700);
   });
 
+  /**
+   * The columns are on the row the detail screen already reads. Leaving them out of its query is
+   * how that screen came to describe a walk as a dumbbell exercise that lasted 45 minutes, with
+   * no ground on it and no route: it never knew it was looking at an outing.
+   */
+  test("the detail of an outing carries its ground, its moving time and its kind", async () => {
+    const completed = require("../db/completed") as typeof import("../db/completed");
+    const exercises = require("../db/exercises") as typeof import("../db/exercises");
+    const squat = (await exercises.listExercises()).find((e) => e.enName === "Squat");
+    if (!squat) throw new Error("Seeded exercise 'Squat' not found");
+
+    const id = await completed.createCompletedSession({
+      userLevel: "medium",
+      uuid: "0192-walk-detail",
+      leaguesM: 5700,
+      movingSeconds: 1_982,
+      outing: "walk",
+      xpEarned: 30,
+      exercises: [{ exerciseId: squat.id, sortOrder: 0, result: { type: "time", value: 1_982 } }],
+    });
+
+    const session = await completed.getCompletedSessionById(id);
+    expect(session?.leaguesM).toBe(5700);
+    expect(session?.movingSeconds).toBe(1_982);
+    expect(session?.outing).toBe("walk");
+  });
+
   test("a workout writes neither, rather than a zero that means nothing", async () => {
     const completed = require("../db/completed") as typeof import("../db/completed");
     const exercises = require("../db/exercises") as typeof import("../db/exercises");

--- a/__tests__/db-dev-seed-expedition.test.ts
+++ b/__tests__/db-dev-seed-expedition.test.ts
@@ -97,11 +97,13 @@ describe("db/devSeedExpedition", () => {
 
   test("clearing takes the points with it, which no foreign key would", async () => {
     const { uuid } = await seeder().seedExpedition();
-    expect(await gps().hasPoints(uuid)).toBe(true);
+    // `previewPathsFor`, because that is what the journal calls: it wants the line, not just the
+    // fact that there is one, and `hasPoints` went with the door that used to draw a map pin.
+    expect((await gps().previewPathsFor([uuid])).get(uuid)?.length).toBeGreaterThan(0);
 
     await seeder().clearSeededExpeditions();
 
-    expect(await gps().hasPoints(uuid)).toBe(false);
+    expect((await gps().previewPathsFor([uuid])).get(uuid)).toBeUndefined();
     expect(t.sqlite.prepare("SELECT COUNT(*) AS c FROM gps_points").get() as { c: number }).toEqual(
       { c: 0 },
     );

--- a/__tests__/store-expedition.test.ts
+++ b/__tests__/store-expedition.test.ts
@@ -411,6 +411,54 @@ describe("stores/expedition", () => {
    * that costs; here they are worth a breadcrumb, because a GPS that drops out on a de-Googled
    * ROM is exactly the field report nobody can reproduce at a desk.
    */
+  /**
+   * The panel used to print the whole outing's average and call it pace, which after an hour a
+   * hard four hundred metres moves by six seconds per kilometre. The receiver has been reporting
+   * a speed on every fix the whole time.
+   */
+  describe("how fast the hero is going now", () => {
+    test("means the last twenty seconds, so one jittery fix does not move the figure", async () => {
+      const store = require("@/stores/expedition")
+        .useExpeditionStore as typeof import("@/stores/expedition").useExpeditionStore;
+      await store.getState().begin("s-speed", NOTIFICATION, false, "metric");
+
+      for (let i = 0; i < 5; i++) emit(walking(i));
+      expect(store.getState().recentSpeedMps).toBeCloseTo(1.4, 5);
+
+      // One fix at a sprint, four seconds of walking around it: the mean moves, the reading does
+      // not jump to the sprint.
+      emit({ ...walking(5), speed: 5.6 });
+      const mean = store.getState().recentSpeedMps;
+      expect(mean).toBeGreaterThan(1.4);
+      expect(mean).toBeLessThan(2.5);
+    });
+
+    test("forgets what is older than the window, so a walk after a run reads as a walk", async () => {
+      const store = require("@/stores/expedition")
+        .useExpeditionStore as typeof import("@/stores/expedition").useExpeditionStore;
+      await store.getState().begin("s-window", NOTIFICATION, false, "metric");
+
+      emit({ ...walking(0), speed: 5.6 });
+      // Thirty seconds later, past the twenty second window, at a walk.
+      emit({ ...walking(30), speed: 1.4 });
+
+      expect(store.getState().recentSpeedMps).toBeCloseTo(1.4, 5);
+    });
+
+    test("says nothing rather than zero when the receiver reports no speed at all", async () => {
+      const store = require("@/stores/expedition")
+        .useExpeditionStore as typeof import("@/stores/expedition").useExpeditionStore;
+      await store.getState().begin("s-none", NOTIFICATION, false, "metric");
+
+      emit({ ...walking(0), speed: null });
+      emit({ ...walking(1), speed: null });
+
+      // Null, not 0: a receiver that omits the field is not a hero standing still, and the panel
+      // falls back to the outing's average rather than printing a standstill.
+      expect(store.getState().recentSpeedMps).toBeNull();
+    });
+  });
+
   describe("a trace that goes quiet", () => {
     test("leaves a breadcrumb when the provider is switched off", async () => {
       await store.getState().begin("s1", NOTIFICATION, false, "metric");

--- a/__tests__/store-session.test.ts
+++ b/__tests__/store-session.test.ts
@@ -362,6 +362,22 @@ describe("useSessionStore", () => {
       bossMock.getOrCreateBossFight.mockResolvedValue(null);
     });
 
+    test("never starts over a live session, because its name is what the fixes are filed under", async () => {
+      // An outing paused by the hardware back button still holds its uuid, and every GPS point
+      // written so far is filed under it. `startSession` used to overwrite both unconditionally,
+      // and the guard lived on the Home tile alone: the hero going back to change a walk's goal,
+      // through the quest screen, lost the walk. Now the store refuses, and the caller lands the
+      // hero on the session that is already running.
+      await store.getState().startSession(mockQuest, "medium");
+      const live = store.getState().sessionUuid;
+      store.setState({ status: "running" });
+
+      await store.getState().startSession(mockQuest, "hard");
+
+      expect(store.getState().sessionUuid).toBe(live);
+      expect(store.getState().userLevel).toBe("medium");
+    });
+
     test("resolves the adventure from the run step alone", async () => {
       await store.getState().startSession(mockQuest, "medium", { adventureRunStepId: 5 });
 
@@ -645,6 +661,11 @@ describe("useSessionStore", () => {
 
       // Through the real door, not the fixture: the point is that starting a session is what
       // mints the name, and that the same one survives to the row.
+      //
+      // Idle first, because this describe's setup leaves a session running and the store now
+      // refuses to start one over a live one: overwriting `sessionUuid` orphans every GPS fix
+      // filed under it. Nothing in this test is about that guard, so it starts from a clean one.
+      store.setState({ status: "idle" });
       await store.getState().startSession(mockQuest, "medium");
       const atStart = store.getState().sessionUuid;
       expect(atStart).toEqual(expect.any(String));
@@ -1199,6 +1220,10 @@ describe("useSessionStore", () => {
       realBegin = useExpeditionStore.getState().begin;
       const begin = jest.fn<Promise<boolean>, unknown[]>().mockResolvedValue(true);
       useExpeditionStore.setState({ begin: begin as unknown as typeof realBegin });
+      // This describe sits outside `useSessionStore`'s own reset, so it inherits whatever status
+      // the previous file left behind, and the store now refuses to start a session over a live
+      // one. Idle is the state a hero opening a quest is actually in.
+      useSessionStore.setState({ status: "idle" });
     });
 
     afterEach(() => {
@@ -1677,6 +1702,9 @@ describe("the day's quest", () => {
     (isDailyQuest as jest.Mock).mockResolvedValue(true);
     (hasSessionForQuestToday as jest.Mock).mockResolvedValue(false);
     (computeSessionXp as jest.Mock).mockClear();
+    // Outside `useSessionStore`'s own reset, so the status is whatever the last test left, and
+    // the store now refuses to start a session over a live one.
+    useSessionStore.setState({ status: "idle" });
   });
 
   afterEach(() => {

--- a/app/(tabs)/journal/[id].tsx
+++ b/app/(tabs)/journal/[id].tsx
@@ -12,18 +12,22 @@ import {
   ChevronRight,
   Clock,
   Dumbbell,
-  Map as MapIcon,
+  Footprints,
   Repeat,
   Target,
 } from "@/components/icons";
+import { TraceThumb } from "@/components/journal/TraceThumb";
 import { getDateTimeFormat } from "@/constants/dateFormatters";
+import { formatDistance } from "@/constants/distanceFormat";
 import { formatDuration, getCompletedSessionById } from "@/db";
 import type { CompletedSession } from "@/db/completed";
 import { EQUIPMENT_LABELS } from "@/db/equipment";
-import { hasPoints } from "@/db/gps";
+import { hasGround } from "@/db/expeditions";
+import { previewPathsFor } from "@/db/gps";
 import { MUSCLE_LABELS } from "@/db/muscles";
 import { getCached, setCached } from "@/db/queryCache";
 import { listQuestTemplates } from "@/db/quests";
+import type { LngLat } from "@/src/gps/trace";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useSettingsStore } from "@/stores/settings";
@@ -36,12 +40,30 @@ const parseId = (raw?: string | string[]): number | null => {
   return Number.isFinite(num) ? num : null;
 };
 
+/**
+ * The run's own line, or nothing.
+ *
+ * The points themselves rather than `hasPoints`: one query answers both "is there a door" and
+ * "what is behind it", and until 2026-09-11 the door was the only thing on this screen that knew
+ * the hero had been outside. Never allowed to fail the screen either: a missing trace is not
+ * worth losing the session over, and a swallowed failure is not allowed.
+ */
+async function traceFor(uuid: string | null): Promise<readonly LngLat[]> {
+  if (!uuid) return [];
+  const paths = await previewPathsFor([uuid]).catch((error) => {
+    reportError("journal.trace", error);
+    return null;
+  });
+  return paths?.get(uuid) ?? [];
+}
+
 export default function SessionDetailScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const { t } = useTranslation();
   const language = useSettingsStore((s) => s.language);
+  const distanceUnit = useSettingsStore((s) => s.distanceUnit);
 
   const sessionId = parseId(params.id);
 
@@ -53,7 +75,7 @@ export default function SessionDetailScreen() {
   );
   // Whether this session left a trace. Every strength quest has none, and a door onto an empty
   // map is worse than no door — see app/recap.tsx.
-  const [hasTrace, setHasTrace] = useState(false);
+  const [trace, setTrace] = useState<readonly LngLat[]>([]);
   const [questTitle, setQuestTitle] = useState<string>(() =>
     sessionId != null ? (getCached<string>(`sessionTitle:${sessionId}:${language}`) ?? "") : "",
   );
@@ -73,16 +95,7 @@ export default function SessionDetailScreen() {
           return;
         }
         setSession(data);
-        // Never allowed to fail the screen: whether a door appears is not worth losing the
-        // session over, and a swallowed failure is not allowed either.
-        setHasTrace(
-          data.uuid
-            ? await hasPoints(data.uuid).catch((e) => {
-                reportError("journal.hasTrace", e);
-                return false;
-              })
-            : false,
-        );
+        setTrace(await traceFor(data.uuid));
 
         // Fetch quest title
         if (data.questId) {
@@ -236,6 +249,16 @@ export default function SessionDetailScreen() {
                       label={durationLabel}
                       tone="secondary"
                     />
+                    {/* An outing's own unit, next to its duration, the way the history row it was
+                        tapped from already shows it. Without it this screen described a walk with
+                        a duration and a difficulty and nothing else. */}
+                    {hasGround(session) && (
+                      <Tag
+                        icon={<Footprints size={12} color="$text" />}
+                        label={formatDistance(session.leaguesM, distanceUnit)}
+                        tone="secondary"
+                      />
+                    )}
                     <Tag
                       label={t(`quests.level_${session.userLevel}`, session.userLevel)}
                       tone="primary"
@@ -256,7 +279,7 @@ export default function SessionDetailScreen() {
               </Card>
 
               {/* The way out to the map. Only for a session that actually recorded ground. */}
-              {hasTrace && !!session.uuid && (
+              {trace.length > 0 && !!session.uuid && (
                 <Card
                   bg="$surface"
                   onPress={() =>
@@ -265,10 +288,21 @@ export default function SessionDetailScreen() {
                   accessibilityLabel={t("recap.open", "See the ground covered")}
                 >
                   <XStack items="center" gap="$3">
-                    <MapIcon size={20} color="$resourceGold" strokeWidth={2.5} />
-                    <Text flex={1} fontWeight="700" fontSize={16} color="$text">
-                      {t("recap.open", "See the ground covered")}
-                    </Text>
+                    {/* The run's own shape, not a map pin: the trace is already loaded and the
+                        door might as well show what is behind it. Same drawing and same gold as
+                        the history row this screen was tapped from. */}
+                    <TraceThumb points={trace} size={56} />
+                    <YStack flex={1} gap="$1">
+                      <Text fontWeight="700" fontSize={16} color="$text">
+                        {t("recap.open", "See the ground covered")}
+                      </Text>
+                      {session.movingSeconds ? (
+                        <Text fontSize={13} color="$textSecondary">
+                          {t("session.expedition_moving", "Moving")}{" "}
+                          {formatDuration(session.movingSeconds)}
+                        </Text>
+                      ) : null}
+                    </YStack>
                     <ChevronRight size={20} color="$textSecondary" />
                   </XStack>
                 </Card>

--- a/app/recap.tsx
+++ b/app/recap.tsx
@@ -19,7 +19,12 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { useToast } from "@/components/common/Toast";
 import { ChevronLeft, Share2 } from "@/components/icons";
 import { getDateTimeFormat } from "@/constants/dateFormatters";
-import { formatClock, formatDistance, formatPace } from "@/constants/distanceFormat";
+import {
+  formatClock,
+  formatDistance,
+  formatPace,
+  formatSpeedAsPace,
+} from "@/constants/distanceFormat";
 import { MAP_ATTRIBUTION, mapStyle, mapStyleNoTiles } from "@/constants/mapStyle";
 import { rawColors } from "@/constants/rawColors";
 import { outingSession, pointsOf } from "@/db/gps";
@@ -151,9 +156,8 @@ function SpeedLegend({
   const { t } = useTranslation();
   if (range === null && best === null) return null;
 
-  // A speed, as the pace of one hour held at it. `formatPace` is the only thing in this app that
-  // turns ground and time into a pace, and an hour is far above the ten metres it refuses under.
-  const paceAt = (speed: number) => formatPace(speed * 3600, 3_600_000, unit);
+  // A speed, as the pace of one hour held at it. One conversion, in constants/distanceFormat.
+  const paceAt = (speed: number) => formatSpeedAsPace(speed, unit);
 
   return (
     <YStack gap="$2" testID="recap-speed-legend">

--- a/components/journal/TrendsCard.tsx
+++ b/components/journal/TrendsCard.tsx
@@ -24,7 +24,7 @@ function TrendsCardComponent() {
   const [weeklyTrends, setWeeklyTrends] = useState<WeeklyTrend[]>([]);
   const [monthlyTrends, setMonthlyTrends] = useState<MonthlyTrend[]>([]);
   const [sessionsAnalysis, setSessionsAnalysis] = useState<TrendAnalysis | null>(null);
-  const [minutesAnalysis, setMinutesAnalysis] = useState<TrendAnalysis | null>(null);
+  const [xpAnalysis, setXpAnalysis] = useState<TrendAnalysis | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   const loadData = useCallback(async () => {
@@ -33,7 +33,7 @@ function TrendsCardComponent() {
       setWeeklyTrends(summary.weeklyTrends);
       setMonthlyTrends(summary.monthlyTrends);
       setSessionsAnalysis(summary.sessionsAnalysis);
-      setMinutesAnalysis(summary.minutesAnalysis);
+      setXpAnalysis(summary.xpAnalysis);
     } catch (error) {
       // A card that failed to load looks exactly like a card with nothing to show.
       reportError("journal.trends", error);
@@ -67,14 +67,14 @@ function TrendsCardComponent() {
       return getDateTimeFormat(language, { month: "short" }).format(item.monthStart);
     };
     const maxSessions = Math.max(1, ...currentData.map((d) => d.sessionCount));
-    const maxMinutes = Math.max(1, ...currentData.map((d) => d.totalMinutes));
+    const maxXp = Math.max(1, ...currentData.map((d) => d.totalXp));
     return currentData.slice(-8).map((item) => ({
       key: "weekKey" in item ? item.weekKey : item.monthKey,
       label: formatPeriodLabel(item),
       sessionCount: item.sessionCount,
-      totalMinutes: item.totalMinutes,
+      totalXp: item.totalXp,
       sessionHeight: (item.sessionCount / maxSessions) * 100,
-      minutesHeight: (item.totalMinutes / maxMinutes) * 100,
+      xpHeight: (item.totalXp / maxXp) * 100,
     }));
   }, [currentData, language]);
 
@@ -174,7 +174,7 @@ function TrendsCardComponent() {
         ) : (
           <>
             {/* Trend Badges */}
-            {viewMode === "weekly" && (sessionsAnalysis || minutesAnalysis) && (
+            {viewMode === "weekly" && (sessionsAnalysis || xpAnalysis) && (
               <XStack gap="$2" flexWrap="wrap">
                 {!!sessionsAnalysis && (
                   <XStack items="center" gap="$1">
@@ -184,12 +184,12 @@ function TrendsCardComponent() {
                     {renderTrendBadge(sessionsAnalysis)}
                   </XStack>
                 )}
-                {!!minutesAnalysis && (
+                {!!xpAnalysis && (
                   <XStack items="center" gap="$1">
                     <Text fontSize={12} color="$text" opacity={0.6}>
-                      {t("journal.trends_minutes")}:
+                      {t("journal.trends_xp")}:
                     </Text>
-                    {renderTrendBadge(minutesAnalysis)}
+                    {renderTrendBadge(xpAnalysis)}
                   </XStack>
                 )}
               </XStack>
@@ -227,25 +227,30 @@ function TrendsCardComponent() {
               </XStack>
             </YStack>
 
-            {/* Minutes Bar Chart */}
+            {/* What the effort was worth, not how long it took.
+                XP is priced off reps, tempo and difficulty, so it is the only effort-weighted
+                number the journal owns; minutes went *up* when the hero was slower on a quest of
+                fixed prescription, which is the opposite of what a progress card should say. The
+                series, its analysis and both translations already existed and were dropped at
+                this card's boundary. */}
             <YStack gap="$2">
               <Text fontSize={12} fontWeight="700" color="$text" opacity={0.7}>
-                {t("journal.trends_minutes")}
+                {t("journal.trends_xp")}
               </Text>
               <XStack
                 gap="$1"
                 items="flex-end"
                 height={60}
                 accessible
-                accessibilityLabel={`${t("journal.trends_minutes")}: ${bars
-                  .map((b) => `${b.label} ${b.totalMinutes}`)
+                accessibilityLabel={`${t("journal.trends_xp")}: ${bars
+                  .map((b) => `${b.label} ${b.totalXp}`)
                   .join(", ")}`}
               >
                 {bars.map((bar) => (
                   <YStack key={bar.key} flex={1} items="center" gap="$1">
                     <YStack
                       width="100%"
-                      height={`${Math.max(4, bar.minutesHeight)}%`}
+                      height={`${Math.max(4, bar.xpHeight)}%`}
                       bg="$secondary"
                       rounded="$2"
                       borderWidth={1}

--- a/components/session/ExpeditionPanel.tsx
+++ b/components/session/ExpeditionPanel.tsx
@@ -4,7 +4,12 @@ import { Linking } from "react-native";
 import { Paragraph, Text, XStack } from "tamagui";
 import { AppButton } from "@/components/common/AppButton";
 import { Card } from "@/components/common/Card";
-import { formatClock, formatDistance, formatPace } from "@/constants/distanceFormat";
+import {
+  formatClock,
+  formatDistance,
+  formatPace,
+  formatSpeedAsPace,
+} from "@/constants/distanceFormat";
 import { useSessionTimer } from "@/hooks/useSessionTimer";
 import type { TrackState } from "@/src/gps/track";
 import { reportError } from "@/src/reportError";
@@ -56,6 +61,7 @@ export function ExpeditionPanel() {
   const track = useExpeditionStore((state) => state.track);
   const error = useExpeditionStore((state) => state.error);
   const lastFix = useExpeditionStore((state) => state.lastFix);
+  const recentSpeedMps = useExpeditionStore((state) => state.recentSpeedMps);
   const goalReached = useExpeditionStore((state) => state.goalReached);
   const unit = useSettingsStore((state) => state.distanceUnit);
   const goal = useSessionStore((state) => state.goal);
@@ -99,7 +105,19 @@ export function ExpeditionPanel() {
 
   const clock = formatClock(recorded * 1000);
   const distance = formatDistance(track.distanceM, unit);
-  const pace = formatPace(track.distanceM, track.movingMs, unit);
+  /**
+   * The pace of the last twenty seconds, not of the whole outing.
+   *
+   * The average is a figure that stops moving: after an hour, a hard four hundred metres shifts
+   * it by six seconds per kilometre, so the panel answered "how fast has this walk been" to a
+   * hero asking "how fast am I going". The average is still what the recap prints, where looking
+   * back is the point. Falls back to it while the window is empty, which is the first few
+   * seconds and any receiver that reports no speed at all.
+   */
+  const pace =
+    recentSpeedMps === null
+      ? formatPace(track.distanceM, track.movingMs, unit)
+      : formatSpeedAsPace(recentSpeedMps, unit);
 
   /**
    * The big figure carries the unit the hero set out in: metres when the goal is metres, the

--- a/constants/distanceFormat.ts
+++ b/constants/distanceFormat.ts
@@ -47,6 +47,21 @@ export function formatDistance(metres: number, unit: DistanceUnit): string {
  * on a panel that read "0 m" one line above. The two lines now agree on what going somewhere is,
  * because they read the same rule.
  */
+/**
+ * The pace of one instant, from a speed the receiver reported.
+ *
+ * `formatPace` below answers "how fast has this outing been", which is a number a hard four
+ * hundred metres moves by six seconds per kilometre after an hour. This one answers "how fast am
+ * I going", which is the question a hero asks mid-run, and it is a different figure entirely.
+ *
+ * An hour of that speed, in metres, over an hour: the same division, so both readings round the
+ * same way and neither can disagree with the other about what a kilometre is. The recap's colour
+ * ramp has been doing exactly this inline since it was written.
+ */
+export function formatSpeedAsPace(metresPerSecond: number, unit: DistanceUnit): string {
+  return formatPace(metresPerSecond * 3600, 3_600_000, unit);
+}
+
 export function formatPace(metres: number, movingMs: number, unit: DistanceUnit): string {
   if (
     !Number.isFinite(metres) ||

--- a/db/completed.ts
+++ b/db/completed.ts
@@ -118,6 +118,15 @@ export type CompletedSession = {
   notes: string;
   feedback: FeedbackCode | null;
   performedAt: Date;
+  /**
+   * The three an outing is made of, on the same row as everything above and left out of this
+   * query until 2026-09-11: the detail screen showed a walk as a dumbbell exercise that lasted
+   * 45 minutes, with no ground and no route, because it never learned outings exist. The history
+   * list has always selected them.
+   */
+  leaguesM: number | null;
+  movingSeconds: number | null;
+  outing: Locomotion | null;
   exercises: CompletedExercise[];
 };
 
@@ -591,6 +600,9 @@ export async function getCompletedSessionById(id: number): Promise<CompletedSess
       sessionNotes: completedQuest.notes,
       sessionFeedback: completedQuest.feedback,
       sessionPerformedAt: completedQuest.performedAt,
+      leaguesM: completedQuest.leaguesM,
+      movingSeconds: completedQuest.movingSeconds,
+      outing: completedQuest.outing,
     })
     .from(completedQuest)
     .where(eq(completedQuest.id, id))
@@ -608,6 +620,9 @@ export async function getCompletedSessionById(id: number): Promise<CompletedSess
     notes: head.sessionNotes,
     feedback: (head.sessionFeedback as FeedbackCode | null) ?? null,
     performedAt: head.sessionPerformedAt,
+    leaguesM: head.leaguesM,
+    movingSeconds: head.movingSeconds,
+    outing: head.outing,
     exercises: [],
   };
 

--- a/db/gps.ts
+++ b/db/gps.ts
@@ -120,22 +120,6 @@ export async function previewPathsFor(
 }
 
 /**
- * Whether a session recorded any ground at all.
- *
- * The journal's door to the recap, and the reason it is `limit(1)` rather than `pointsOf().length`:
- * every strength quest in the app has no points, and asking that question must not read a
- * 45-minute trace to answer "none".
- */
-export async function hasPoints(sessionId: string): Promise<boolean> {
-  const rows = await db
-    .select({ t: gpsPoints.t })
-    .from(gpsPoints)
-    .where(eq(gpsPoints.sessionId, sessionId))
-    .limit(1);
-  return rows.length > 0;
-}
-
-/**
  * One league is a kilometre here. The one place that knows the scale: the road's floors, the
  * oath's target and every "N leagues" a screen prints divide by this.
  *

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,9 @@ related: [../README.md]
 - [exercise-colors.md](exercise-colors.md) — Muscle group → color mapping
 - [audit-protocol.md](audit-protocol.md) — Capturing every screen, then judging it with adversarial personas
 - [audits/2026-09-10.md](audits/2026-09-10.md) — ⚠️ 55 findings from four personas, 12 blockers, 4 confirmed in the code
+- [audits/2026-09-10-home-and-outings.md](audits/2026-09-10-home-and-outings.md) — Moves between opening the app and being under way
+- [audits/2026-09-10-outings.md](audits/2026-09-10-outings.md) — The live outing, its speed, and where the trace stops being drawn
+- [audits/2026-09-10-stats.md](audits/2026-09-10-stats.md) — Which stats cards earn their place
 
 ## Consistency contract
 

--- a/docs/design/audits/2026-09-10-home-and-outings.md
+++ b/docs/design/audits/2026-09-10-home-and-outings.md
@@ -1,0 +1,291 @@
+---
+title: Design audit, starting a session and setting up an outing
+type: design
+status: active
+updated: 2026-09-10
+related: [2026-09-10.md, ../audit-protocol.md]
+---
+
+# Design audit, starting a session and setting up an outing
+
+The brief, from the person who owns the product: *"sur la partie home, je trouve que le départ des
+quêtes et leur modification quand ce sont des 'sorties' extérieures ne sont pas ergonomiques."*
+Two surfaces then: how a session gets started from Home, and how an outdoor outing gets configured
+before it starts. Not a complaint about how it looks. A complaint about the number of moves, and
+about the outdoor case feeling bolted on.
+
+Built on [2026-09-10.md](2026-09-10.md), which already covers Home's day-one card (§2.10) and the
+quest detail's dilution (§3, "Choosing what to do"). Nothing here repeats those.
+
+Sources: shots `01`, `02`, `03`, `08`, `09`, `10` of the seeded English run; the source of
+[`OutsideBand.tsx`](../../../components/home/OutsideBand.tsx),
+[`useSmartAction.ts`](../../../components/home/useSmartAction.ts),
+[`edit.tsx`](<../../../app/(tabs)/quests/edit.tsx>),
+[`QuestConfigCard.tsx`](../../../components/quests/QuestConfigCard.tsx) and
+[`OutingGoalSheet.tsx`](../../../components/quests/OutingGoalSheet.tsx).
+`13-quest-editor.png` is **still** the Expo dev menu, as §7 of the earlier audit recorded, so every
+editor finding below comes from the code and says so.
+
+**One flow is fine and is not the problem.** `OutingGoalSheet` is the right screen: presets in the
+hero's own vocabulary (20 / 30 / 45 / 60 min, 5 km / 10 km / half), it opens on the tab of the goal
+that would actually run, and its input survives a French comma. The wound is everything between
+Home and it, and the fact that what it writes does not survive the trip back.
+
+---
+
+## The moves, counted
+
+**Starting the workout Home is already offering.** 2 taps, 2 screens.
+
+1. Open the app. Home's stage names the quest, its art, "3 exercises · Circuit · ≈ 10 min" and why
+   it was picked (shot 01).
+2. Tap **See the quest**. Lands on `/quests/{id}`.
+3. Tap **Start Quest**, pinned in the bottom bar, no scroll needed (shot 09).
+
+Mid-week, the hero needs step 3. Step 2 is a screen that re-prints the four facts already read on
+Home, then adds a level row, a config card and a card per movement.
+
+**Starting a different workout.** 3 taps minimum plus a hunt, 5 with a filter.
+
+1. Home → tab **Quests**.
+2. Optional: open one of Duration / Type / Muscles / Equipment, then tap a chip. +2 taps.
+3. Scroll the 37-card list. At roughly three cards per screen (shot 08), that is up to a dozen
+   swipes.
+4. Tap the card → detail. 5. Tap **Start Quest**.
+
+Mid-week the hero almost always wants a workout they have already done. Nothing on this path is
+about that.
+
+**Starting an outing at the distance or duration wanted today.** 5 taps, 3 surfaces, 2 scrolls.
+
+1. Home → tap **Set up** in the band header (shot 01).
+2. Tap the tile → `/quests/{id}?from=home`.
+3. Scroll to **Adjust this quest**. Open by default on an outing (`singleControl`), but below the
+   cover, the title card and the tag row.
+4. Tap **Set up the outing**.
+5. Tap a preset chip. A typed value costs 3 taps instead of 1.
+6. Scroll back down, tap **Start Quest**.
+
+The hero needs step 5. Everything else is transport.
+
+**Changing an outing's target before starting it.** Identical to the above: there is no second
+route, and the change does not survive (finding 1).
+
+**Starting an outing with no number on it.** 1 tap on the tile. This one is genuinely good and is
+the shape everything else should be measured against.
+
+---
+
+## Findings
+
+### 1
+
+**[where]** outing setup
+**[from]** source, [`components/home/OutsideBand.tsx:205-213`](../../../components/home/OutsideBand.tsx), against [`app/(tabs)/quests/[id].tsx:556`](<../../../app/(tabs)/quests/[id].tsx>)
+**[severity]** blocker
+**[claim]** The band's tile throws away the goal the hero set on the quest screen, so the whole five-tap setup flow has to be walked again every single time they go out.
+**[evidence]** `startOuting` calls `loadConfiguredQuest(questId, Difficulty.Medium)` and then
+`startSession(loaded.quest, loaded.level, { goal: null })`. The `null` is hard-coded. A distance
+lives in `config.distanceM` and is read only by `outingGoal()`, which this path never calls, so a
+saved 10 km is invisible here. Meanwhile the card that wrote it says, in its own hint, *"Saved for
+this quest. It comes back next time."* It does not. The quest screen, one file over, passes
+`goal: outingGoal(quest, config.distanceM ?? null)`.
+**[fix]** Have `loadConfiguredQuest` return the `saved` config it already reads (it currently drops
+it on the floor at line 314), and pass `outingGoal(loaded.quest, saved?.distanceM ?? null)`. The
+`null` intent is preserved for a hero who never set one: `outingGoal` returns the slot's duration
+only when a duration was written, and the seed's suggestion is not a hero's choice, so gate on
+`hasQuestOverrides(saved)` if the "no number on it" rule must hold exactly.
+
+### 2
+
+**[where]** outing setup
+**[from]** source, [`app/(tabs)/quests/[id].tsx:542-563`](<../../../app/(tabs)/quests/[id].tsx>) against [`components/home/OutsideBand.tsx:158-164`](../../../components/home/OutsideBand.tsx)
+**[severity]** blocker
+**[claim]** The Set up path bypasses the live-session guard the one-tap path has, so configuring an outing while one is paused silently destroys it and orphans every GPS fix it wrote.
+**[evidence]** `startOuting` refuses to start over a live session: *"an outing paused by the
+hardware back button still holds its uuid and its points. `startSession` would overwrite it and
+orphan every fix it had written, so the tap rejoins it instead."* The tile's `setup` branch three
+lines below pushes straight to `/quests/{id}` with no such check, and `proceedToSession` on that
+screen guards only against a double tap (`isStarting`). `startSession` then mints a fresh
+`sessionUuid` and overwrites the store unconditionally. The hero who wanted to *change* a goal is
+exactly the hero most likely to have a walk paused.
+**[fix]** Move the guard into `startSession` itself, where every caller routes through: if `status`
+is neither `idle` nor `finished`, refuse and let the caller navigate to `/session`. One check, and
+`OutsideBand` can then delete its own copy.
+
+### 3
+
+**[where]** outing setup
+**[from]** source, [`components/home/OutsideBand.tsx:137,245-259,304-315`](../../../components/home/OutsideBand.tsx) and shot 01
+**[severity]** friction
+**[claim]** "Set up" is an invisible mode toggle that rewrites what all three tiles do, and it resets itself on every focus, so the hero cannot tell which gesture they are about to make.
+**[evidence]** `setup` is a boolean. On, a tile opens a screen; off, a tile starts a GPS session.
+The only visible difference is the 22 dp play disc appearing or disappearing from the tile corner
+(shot 01, top right of each thumbnail). The word "Set up" does not change, does not gain a filled
+state beyond a colour swap on a 13 px label, and the sentence explaining the mode exists only in
+`accessibilityLabel` ("Set up an outing before heading out") where no sighted user reads it.
+`useFocusEffect` clears it on every focus, so coming back from the quest screen puts the tiles back
+in "leaves now" mode under a thumb that just learned the opposite.
+**[fix]** Delete the mode. Put the goal on the tile: a second line under the name showing the saved
+goal, or "No goal" when there is none, and long-press or a 44 dp chevron for the sheet. If the mode
+must stay for now, make the tiles visibly different in it (swap the play disc for the sliders glyph
+rather than removing it) and stop resetting it on focus.
+
+### 4
+
+**[where]** outing setup
+**[from]** source, [`components/quests/QuestConfigCard.tsx:264-305`](../../../components/quests/QuestConfigCard.tsx)
+**[severity]** friction
+**[claim]** The single decision an outing has is buried four containers deep, behind a disclosure whose title asks about the quest and not about tonight.
+**[evidence]** The path to one number is: quest screen → a card headed **Adjust this quest** →
+inside it an `OutingGoalRow` → a button reading **Set up the outing** → a modal sheet headed **How
+long, or how far** → a chip. Three separate headings say the same thing in three registers before
+the hero touches a value. On an outing that card holds one control (`ShapeSteppers` suppresses
+rounds, `restsBetween*` are both false, the per-slot steppers are replaced by a plain name), so the
+disclosure is a fold over a single row.
+**[fix]** On an outing, drop the fold and the intermediate row: render the goal chips
+(`DURATION_PRESETS_SECONDS`, `DISTANCE_PRESETS_M`) inline on the quest screen where the level chips
+sit on a workout, with "Other" opening the sheet. The sheet stays for typed values only.
+
+### 5
+
+**[where]** quest editor
+**[from]** source, [`app/(tabs)/quests/edit.tsx:436-470`](<../../../app/(tabs)/quests/edit.tsx>) with [`db/targets.ts:23,105-114`](../../../db/targets.ts)
+**[severity]** friction
+**[claim]** Authoring an outing in the editor asks for its duration in five-second steps over a twelve-hour range, so a 45 minute walk is 534 taps on a plus button.
+**[evidence]** `addExercise` seeds an expedition movement at `DEFAULT_TARGET_VALUE.time`, which is
+**30**. The row's `Stepper` runs `min` 1 to `targetRangeFor("time", NON_REP_STYLE).max`, which is
+`OUTING_TARGET_MAX`, **43 200**, with `step = REST_STEP = 5`. 30 s to 2 700 s is 534 presses. This
+is the exact wound `OutingGoalSheet` was built to close, and its own header comment says so:
+*"the stepper this replaces moved in five-second steps, so 15 min to 45 min was 360 taps."* The
+quest screen got the fix; the editor never did.
+**[fix]** Reuse it. When the picked movement's style is `NON_REP_STYLE`, replace the target
+`Stepper` with the same preset chips plus "Other", and seed a new outdoor slot at 30 minutes rather
+than 30 seconds.
+
+### 6
+
+**[where]** quest editor
+**[from]** source, [`app/(tabs)/quests/edit.tsx:428-499`](<../../../app/(tabs)/quests/edit.tsx>)
+**[severity]** friction
+**[claim]** The editor does not know outings exist: it asks a walk how many rounds and how long to rest between them, and offers no way to write a distance at all.
+**[evidence]** `pickableExercises` filters on `retiredAt` only, so the three expedition movements
+are pickable and a hero can author their own outing, which
+[`expeditions.md`](../../gameplay/expeditions.md) says is supported. The form then renders **Rounds**,
+**Rest** ("Between exercises") and **Round rest** ("Between rounds") unconditionally. The quest
+screen suppresses exactly these for an outing, and `QuestConfigCard` explains why: *"Three rounds of
+walking is not a thing anyone does, and a control offered on a screen is a decision asked of the
+hero."* The editor asks all three. The per-row unit chips are **Reps** and **Seconds**; there is no
+distance, so a hero-written 10 km outing cannot be authored, only configured after the fact through
+the quest screen.
+**[fix]** Port the same predicate: when every picked movement is outdoors, hide Rounds and both
+rests, and turn the unit chips into Duration / Distance. `isOutingSession` already exists in
+`db/expeditions.ts` and takes the shape the editor is holding.
+
+### 7
+
+**[where]** home
+**[from]** shot 01, source [`components/home/useSmartAction.ts:66-89`](../../../components/home/useSmartAction.ts) and [`components/home/OutsideBand.tsx:109-114`](../../../components/home/OutsideBand.tsx)
+**[severity]** friction
+**[claim]** Home's one filled button navigates instead of starting, on a rule the app has already broken twelve pixels lower down.
+**[evidence]** The earlier audit raised the symptom (§3, "Home's one filled button opens a page
+about the workout instead of starting it"); this is the cause and the counter-argument. The comment
+on `questAction` states the rule: *"Only the detail screen starts a session, Home never pushes a
+session route."* `OutsideBand`, rendered directly under it, pushes a session route on a single tap,
+and its own comment argues the case: *"Going out is a decision taken while walking towards the door,
+and the screen that used to sit in between only ever asked one question the leaver did not have."*
+That argument is not about the outdoors. It is about a hero who has already decided, which is every
+mid-week open of this app. Two adjacent controls on one viewport, one starting and one browsing, and
+the browsing one is the primary blue.
+**[fix]** Make **Start** the primary on the stage and demote "See the quest" to a text link under
+the meta line, matching what the band already does. The card names the quest, its art, its movement
+count and its minutes, which is the same information the tile carries with less.
+
+### 8
+
+**[where]** home
+**[from]** shots 01, 08, source [`app/(tabs)/quests/index.tsx:531,642`](<../../../app/(tabs)/quests/index.tsx>)
+**[severity]** friction
+**[claim]** Home offers exactly one workout and no second, so wanting anything else costs a tab, a hunt through 37 cards and two more screens, while the pinned set that solves it already exists in the database and Home never reads it.
+**[evidence]** `useSmartAction` is a waterfall that sets one config and returns. Its five rules
+produce a single card. Anything else means the Quests tab, where `galleryOrder(quests, isUserQuest,
+favourites)` already sorts pinned quests to the top and each card carries a star (shot 08, and
+`toggleFavouriteQuest` is wired). Home imports none of it. The stage's own subtext explains the
+algorithm's choice ("Strengthens your weak points: Arms, Chest, Back"), which is an argument, and
+an argument invites disagreement with nowhere to take it.
+**[fix]** A second row under the stage, same tile shape as the band: pinned quests first, then the
+last three completed, each starting on tap. `getFavouriteQuestIds` and `listCompletedSessions` are
+both already there.
+
+### 9
+
+**[where]** outing setup
+**[from]** source, [`components/home/OutsideBand.tsx:304-315`](../../../components/home/OutsideBand.tsx) and shots 09, 10 for the layout it lands on
+**[severity]** friction
+**[claim]** Set up sends a hero who wants one number to the full quest screen, which is built to sell a workout to someone who has not chosen yet.
+**[evidence]** The tile pushes `/quests/{id}?from=home`, the same route the gallery uses. What
+loads above the goal, in order: a 4:3 cover, a title card with the flavour text, a tag row of
+rounds / exercises / rest / estimate / XP / XP-per-minute, then **Adjust this quest**. Shots 09 and
+10 show that stack on a workout; an outing loses only the level row (`isOuting ? null`), so the
+goal sits at roughly the same depth. Below it, a full movement card for a walk, with a description,
+an equipment tag and a muscle list. The hero already picked the quest, on Home, two taps ago.
+**[fix]** With `from=home`, open the goal sheet directly over the band, and let it start the
+session on pick. Finding 3 removes the mode that leads here; this removes the destination.
+
+### 10
+
+**[where]** outing setup
+**[from]** source, [`components/quests/QuestConfigCard.tsx:76-104`](../../../components/quests/QuestConfigCard.tsx)
+**[severity]** friction
+**[claim]** The goal is printed as a label with a button beside it, so the one number on the screen is the one thing on it that cannot be tapped.
+**[evidence]** `OutingGoalRow` renders "Distance / 10.0 km" as two `Text` nodes, then a separate
+full-width outline button reading "Set up the outing" to change it. The value carries `$primaryText`
+and 17 px bold, which is the loudest thing in the card, and it is inert. Every other adjustable
+number on the quest screen is inside a control the hero touches directly.
+**[fix]** Make the value the button. One `AppButton` labelled with the goal itself, "10.0 km",
+opening the sheet, and drop the row above it.
+
+### 11
+
+**[where]** home
+**[from]** shot 01, source [`components/home/OutsideBand.tsx:349-367`](../../../components/home/OutsideBand.tsx)
+**[severity]** polish
+**[claim]** A 22 dp decorative disc is the only thing on Home that distinguishes a control which starts a GPS session from a control which opens a screen.
+**[evidence]** Shot 01: the three tiles are art, a name, and a small play triangle top right. The
+code calls that disc *"the only thing that separates a tile that leaves from a tile that reads"*,
+and it is `pointerEvents="none"`. Every other start in the app is a full-width filled button with a
+verb on it. The prior audit's stranger read the play triangles as "this starts now" and was right,
+which is the problem: the same reading is correct in one mode and wrong in the other.
+**[fix]** Once finding 3 removes the mode, the tile has one meaning and can say it: keep the disc
+and add the goal line under the name, so a tap has a visible consequence written on it.
+
+### 12
+
+**[where]** home
+**[from]** source, [`components/home/useSmartAction.ts:174-192`](../../../components/home/useSmartAction.ts)
+**[severity]** polish
+**[claim]** An oath sworn in leagues promotes an outing to the stage and then routes it through the workout flow, so the hero gets the five-tap setup path for the one goal the app itself chose to feature.
+**[evidence]** Rule 2b picks `listOutings()[0]` and hands it to `questAction`, which builds a "See
+the quest" card. The comment concedes the shape: *"the hero picks the duration on the quest
+screen."* So the one case where Home knows the hero is training for leagues is the case where it
+offers the slowest route to setting a distance, while the band six pixels below can start the same
+quest in one tap.
+**[fix]** When rule 2b fires, make the stage's button open the goal sheet rather than the quest
+screen, with the oath's own unit preselected. Same sheet, one tap instead of five.
+
+---
+
+## Where to start
+
+Two bugs, then the mode.
+
+1. **Finding 2** first: it is the only one that destroys data, it is a guard in `startSession` that
+   every caller already wants, and it deletes duplicated code rather than adding any.
+2. **Finding 1**: the goal the hero saved must be the goal that runs. One value threaded through
+   `loadConfiguredQuest`.
+3. **Finding 3**, which subsumes 9 and 11: the "Set up" mode is the bolted-on feeling the brief
+   names. The tile carries the goal, a chevron opens the sheet, the mode disappears.
+4. **Findings 5 and 6** together, one pass over the editor with predicates and a component that
+   both already exist.
+5. **Finding 7** is one line of hierarchy on the stage and the largest single saving for a
+   mid-week open. **Finding 8** is the follow-up it invites.

--- a/docs/design/audits/2026-09-10-outings.md
+++ b/docs/design/audits/2026-09-10-outings.md
@@ -1,0 +1,380 @@
+---
+title: Design audit, the outing and its trace
+type: design
+status: active
+updated: 2026-09-10
+related: [2026-09-10.md, ../../gameplay/expeditions.md]
+---
+
+# Design audit, the outing and its trace
+
+The mandate, in the owner's words: *"durant la course je trouve ça pas immersif et on n'a pas sa
+vitesse"*, and *"dans l'historique, le tracé d'une course extérieure doit se dessiner là où la
+personne est passée."* Three complaints: the live screen is not immersive, it does not show
+current speed, and the history should draw the route actually travelled.
+
+**No screenshot exists of an outing in progress.** Capturing one needs a GPS fix outdoors, and
+[`npm run audit:shots`](../../../scripts/audit-shots.sh) runs on a desk. Every finding about that
+screen is therefore read off the source, and its `[from]` line says so. Findings whose evidence is
+a picture name the shot number.
+
+Twelve findings, hardest first. Nothing here repeats [the whole-app audit of the same
+day](2026-09-10.md); its §2 finding 12, that the recap pays in Strava's currency rather than the
+game's, is taken as settled and built on rather than restated.
+
+---
+
+## The three questions
+
+### 1. What the hero sees, and what the phone already knows
+
+**On the screen.** [`ExpeditionPanel`](../../../components/session/ExpeditionPanel.tsx) is one
+`Card` holding four values and no labels: a 56 px figure, a 24 px figure, a 20 px pace, and a
+13 px status line with the accuracy beside it. Which value takes the 56 px slot depends on the
+goal the hero set minutes earlier: a distance goal leads with the distance, everything else leads
+with the clock, and the other one drops to 24 px. Around that card, an outing renders the ordinary
+session shell: a full-bleed `ExerciseHero` of the movement's plate, the quest name in the HUD row,
+and `OutingFinishButton`. The countdown, the rep counter, the "Replace / I couldn't do this one"
+row and the ghost line are all correctly suppressed for an outing
+([`ActiveExerciseView.tsx`](../../../components/session/ActiveExerciseView.tsx)), so what is left
+between minute one and minute forty-four is three numerals that change and nothing else that does.
+
+**In the pocket.** The ongoing notification carries the quest's name as its title, one state word
+(`Finding the sky` / `On the road` / `Standing still` / `GPS off` / `Goal met`), a second line
+built by `progressLine` in [`stores/expedition.ts`](../../../stores/expedition.ts) as
+`"12:34 · 2.40 km"`, and one `Finish` button. It is rewritten every thirty seconds.
+
+**What the phone knows and does not say.** Speed, and it knows it sixty times a minute:
+
+- **Computed.** `LocationFix.speed` is the receiver's own Doppler reading, arriving at 1 Hz from
+  the native half ([`modules/bati-location/index.ts`](../../../modules/bati-location/index.ts)),
+  `null` only where the chipset reports no speed.
+- **Stored.** [`db/gps.ts`](../../../db/gps.ts) `encode()` writes `speedCms` on every fix. Every
+  outing in the journal carries a per-second speed track.
+- **Derived, after the fact.** [`src/gps/trace.ts`](../../../src/gps/trace.ts) rolls it over a
+  20 s window (`SPEED_WINDOW_MS`), clamps it to the run's own tenth and ninetieth percentiles, and
+  paints the recap's ember-to-gold ramp with it. `bestLeague()` finds the quickest credited
+  kilometre of the run.
+- **Reaching the live screen.** Nothing. The panel subscribes to `lastFix` and spends it on one
+  thing, `formatDistance(lastFix.acc, unit)`, the accuracy line. `lastFix.speed` is in hand, on
+  screen, unread.
+
+The figure that *looks* like speed is `formatPace(track.distanceM, track.movingMs, unit)`: the
+average since the first fix. Finding 1 has the arithmetic.
+
+### 2. Is the outing immersive on this product's own terms
+
+[PRODUCT.md](../../../PRODUCT.md) promises "one tap on the way out and one on the way back, and
+says the rest through a notification". Judged against that promise rather than against Strava, the
+mechanism is sound and the voice is missing.
+
+The mechanism holds. The service outlives the screen, the panel says the phone can go away, the
+screen is deliberately not held awake, `Finish` works from a locked phone, and a walk the OS kills
+resumes from its own points. That is the hard half and it is done.
+
+The voice is the half that is absent. An outing is the one thing in this app paid in leagues, "a
+currency nothing else uses", and **the word "league" never appears while the hero is out**. The
+panel denominates in km, the notification denominates in km, and the one string that names the
+road, `expedition_road`, is on the victory screen. The five events the app detects during an outing
+(the gate opening, a league crossed, a stop, the goal met, the trace breaking) reach the hero as at
+most one word in a 13 px status line, or as a vibration that is the same vibration for two of them.
+`RestView` gets a narrative beat under this audit's sibling recommendations; forty-five minutes on
+the road gets three numerals.
+
+Against the Anti-references, the panel is the closest thing in the app to "a cluttered, stat-heavy
+gym app": tabular numerals, an accuracy figure in metres, a pace, no world. It is not cluttered,
+it is just not Bati. Findings 5, 6 and 12.
+
+### 3. Is the route drawn where the person went
+
+Follow the trace from the table outward. Four consumers read `gps_points`, and they draw three
+different amounts of the run:
+
+| Surface | Draws | Reads |
+|---|---|---|
+| History row | The shape, 42 px, gold, no geography | `previewPathsFor` (48 thinned points, lon/lat only) → `traceToPath` → `TraceThumb` |
+| **Session detail** | **Nothing** | `hasPoints()`, `limit(1)`, used only to decide whether a link appears |
+| Recap | The route, full screen, speed-coloured, league pips, optional basemap | `pointsOf()` → `toTrace()` |
+
+**The drawing stops at the session detail**, and it stops hard: that screen does not know it is
+looking at an outing at all. `getCompletedSessionById`
+([`db/completed.ts:582`](../../../db/completed.ts)) selects nine columns and none of them are
+`leaguesM`, `movingSeconds` or `outing`, although `listCompletedSessions` three hundred lines above
+selects all three. So the screen that sits between the history row and the map prints a walk as
+"Session Details" under a dumbbell, one `Round 1`, and an exercise card with a dumbbell avatar, a
+`Result 45 min` against a `Target 45 min`, and muscle tags. The distance is not on it. The route is
+not on it. Finding 2.
+
+Where the route *is* drawn, two things are wrong with the drawing rather than with its placement.
+The 42 px thumbnail runs a straight gold line through every gap the reducer refused to count,
+which is the exact failure `src/gps/trace.ts` was written to prevent and documents in its own
+header (finding 3). And on the recap, a round is drawn with its start pip underneath its end pip
+and no indication of direction, so the picture of a loop cannot say where the hero set off or which
+way they went (finding 7).
+
+---
+
+## Findings
+
+### 1
+
+[where] during the outing
+[from] source: `components/session/ExpeditionPanel.tsx`, `modules/bati-location/index.ts`,
+`db/gps.ts`, `app/recap.tsx`
+[severity] blocker
+[claim] The receiver reports speed once a second and the panel spends the only figure that could
+carry it on a whole-outing average, which barely moves.
+[evidence] `LocationFix.speed` arrives at 1 Hz and is written to `gps_points.speedCms` on every
+fix; `useExpeditionStore.lastFix` holds the most recent one and the panel already subscribes to it,
+using it for `formatDistance(lastFix.acc, unit)` and nothing else. The figure in the pace slot is
+`formatPace(track.distanceM, track.movingMs, unit)`, cumulative from the first fix. A hero 45
+minutes into a walk at 6:00/km has 7.5 km banked; running the next 400 m at 4:00/km instead of 6:00
+moves the readout from 6:00 to 5:54. Six seconds per kilometre is the whole reward for a hard 400,
+and the same six seconds are what a slight slowdown over the next kilometre would erase. The
+conversion that would fix it is already written, in `SpeedLegend` on the recap:
+`paceAt = (speed) => formatPace(speed * 3600, 3_600_000, unit)`. *(This assumes the hero looks at
+the screen; the pocket half of the fix is the notification line, which today says clock and ground
+and could say the current pace instead of the ground it repeats from the panel.)*
+[fix] Move `paceAt` into `constants/distanceFormat.ts`, which already declares itself the only
+place that converts, and feed it a 20 s mean of `lastFix.speed` kept beside `leaguesCrossed` in the
+expedition store. The 20 s window is `SPEED_WINDOW_MS`, already chosen against a real receiver in
+`src/gps/trace.ts`. The whole-outing average stops being printed live; the recap prints it.
+
+### 2
+
+[where] the session detail
+[from] source: `app/(tabs)/journal/[id].tsx`, `db/completed.ts:582`; shot 21 shows the screen in
+its error state, which the whole-app audit already covers
+[severity] blocker
+[claim] The session detail never learned that outings exist: it drops the ground, the moving time
+and the kind from its own query, and draws no route, so the one screen between the history row and
+the map says a walk was a dumbbell exercise that lasted 45 minutes.
+[evidence] `getCompletedSessionById` selects `id, uuid, questId, userLevel, durationSeconds,
+xpEarned, notes, feedback, performedAt`. `leaguesM`, `movingSeconds` and `outing` are columns on the
+same row, and `listCompletedSessions` in the same file selects all three for the history list. The
+screen's header is a `Dumbbell` beside "Session Details"; an outing renders `Round 1`, an exercise
+card with a dumbbell avatar, `Result 45 min` against `Target 45 min`, and muscle tags on a walk.
+`hasPoints(uuid)` is queried, and its only use is to decide whether a `MapIcon` link appears. The
+trace is in the database, keyed by a uuid the screen is holding, and nothing on the screen is drawn
+from it.
+[fix] Add the three columns to the query and print the ground beside the duration, the way the
+history row already does with `hasGround`. Then put `TraceThumb` at card width inside the existing
+"See the ground covered" row, so the door shows what is behind it. Three lines of SQL and one
+component swap; both already exist.
+
+### 3
+
+[where] the history row
+[from] source: `components/journal/tracePreview.ts`, `db/gps.ts` `previewPathsFor`,
+`src/gps/trace.ts`
+[severity] blocker
+[claim] The thumbnail draws a straight line through every gap the reducer refused to count, which
+is the failure the trace module was written to prevent and says so in its own header.
+[evidence] `traceToPath` emits one `M … L … L …` chain over every point handed to it, with no
+knowledge of `breaksRun`. `src/gps/trace.ts` opens with the rule and the scar: "a picture that then
+draws a straight line across the gap tells the hero they went through it … when this was two
+conditions in two files, the tunnel that cost ten minutes of credit still drew a gold line across
+the hill. One rule, three callers." The recap obeys it, the GPX writer obeys it, the thumbnail is
+the third caller and does not. `previewPathsFor` puts it out of reach as well as out of mind: it
+selects `sessionId, latE7, lonE7` and thins by `ROW_NUMBER`, so the drawing code has coordinates
+and no timestamps, and a 200 m teleport is indistinguishable from a 125 m stride on a 6 km run
+reduced to 48 points.
+[fix] Select `t` in `previewPathsFor` alongside the coordinates, and start a new `M` in
+`traceToPath` when the interval between two kept points is several times the run's own median
+stride. One column, one branch, and the third caller joins the other two.
+
+### 4
+
+[where] during the outing
+[from] source: `stores/expedition.ts` `announceGoalReached`, `announceLeague`, `buzz`
+[severity] blocker
+[claim] Crossing a league and meeting the goal are the same vibration, and on the fix that does
+both they fire twice in a row, on the one channel a pocketed phone has.
+[evidence] `buzz()` is the file's only haptic call, deliberately, so that "a walk cannot end up
+with two ways of buzzing", and it is
+`Haptics.notificationAsync(NotificationFeedbackType.Success)`. Both `announceGoalReached` and
+`announceLeague` call it. In the `onLocation` handler they run in sequence:
+`if (reached && !wasReached) announceGoalReached(...)` then `announceLeague(...)`. A distance goal
+is set with a stepper, so it is almost always a whole number of kilometres, and the fix that meets
+a 5 km goal is the same fix that raises `leaguesOf(track)` to 5. The hero gets two identical
+fire-and-forget buzzes milliseconds apart and no way to know that one was a kilometre and one was
+the end. A league crossing writes nothing anywhere else, by design: "Nothing on screen, no string."
+[fix] The goal keeps `notificationAsync(Success)`. A league takes its own shape, two short
+`impactAsync(Light)`, so the two are told apart by pattern rather than by count. Then call
+`setProgress(progressLine(...))` on a league crossing as well, so the sentence explaining the buzz
+is already on the notification when the hero looks.
+
+### 5
+
+[where] during the outing
+[from] source: `components/session/ExpeditionPanel.tsx`, `stores/expedition.ts` `progressLine`,
+`locales/en.json`
+[severity] friction
+[claim] An outing is the one thing paid in leagues, and the word never appears while the hero is
+out: both surfaces denominate in Strava's kilometres.
+[evidence] The panel prints `formatDistance(track.distanceM, unit)` and `formatPace(...)`, so
+"2.40 km" and "5:48 /km". `progressLine` builds the notification's line as clock plus the same
+`formatDistance`. `expedition_road`, the one string that names the High Road and its leagues, is on
+`ExpeditionSummary`, after the walk is over. `leaguesOf(track)` already exists in the same store,
+computed on every fix for the haptic. The status word "On the road" is the only connective tissue
+between an hour of walking and the building it pays for, and nothing on either surface says which
+road. *(This is the same wound as the whole-app audit's finding 12, one screen earlier: that one is
+about the recap, this one is about the forty-five minutes before it.)*
+[fix] Put the league count in front of the ground on both surfaces, from the counter that is
+already there: `"3 leagues · 2.40 km"` on the notification line, and the same pair as the panel's
+second figure. No new derivation, no new query.
+
+### 6
+
+[where] during the outing
+[from] source: `components/session/ExpeditionPanel.tsx`, `components/journal/TraceThumb.tsx`,
+`components/journal/tracePreview.ts`
+[severity] friction
+[claim] The outing shows no picture of itself, though the component that draws one needs no tiles,
+no network and no map instance, and is already in the repo.
+[evidence] The panel's own header states the decision: "Numbers and nothing else, which is a
+battery decision before it is a design one: the screen dominates the power draw of a session far
+more than the GPS chip does, so the map waits for the recap." That reasoning covers MapLibre, tiles
+and a live camera. It does not cover `TraceThumb`, which is `react-native-svg` and a pure path
+function, is already justified in the journal on exactly the grounds that a virtualized list cannot
+mount a map, and costs one `<Path>`. The panel does not have the points to draw, only the reduced
+`track`, so nothing in the current shape offers it. *(This assumes the hero looks, which on an
+outing is the exception: they look at the start, at a crossing, at the turn, and at the end. The
+shape of the walk so far is the thing worth finding there, and it is the one thing the numbers
+cannot be.)*
+[fix] Keep a capped, thinned `preview: LngLat[]` in the expedition store, pushing one point every
+Nth fix up to `PREVIEW_POINTS`, beside `leaguesCrossed` which is already a running summary of the
+same stream. Draw it with `TraceThumb` at card width above the figures. No tiles, no network, no
+second reducer.
+
+### 7
+
+[where] the recap
+[from] shot 26, plus source: `app/recap.tsx` `endpoints()`
+[severity] friction
+[claim] On a round, the pip that says where the hero set off is painted underneath the pip that
+says where they finished, and nothing on the picture says which way they went.
+[evidence] `endpoints()` returns start and end as two features of one `FeatureCollection`, rendered
+by one `circle` layer, so the later feature paints over the earlier one; on a loop the two
+coordinates are metres apart. In shot 26, "The Warden's Round", the only endpoint on the picture is
+the fire-coloured end pip on the right-hand side of the loop. The green `success` start pip is
+nowhere on the image. The line's colour ramp encodes speed, not time, so the same picture would be
+drawn for the same loop run in the opposite direction.
+[fix] Draw the start in its own layer above the end, at a larger radius, so a round shows a ring
+around a dot instead of one dot. Direction is the second half and it needs a redesign: a `symbol`
+chevron layer needs `glyphs`, which the no-tile style deliberately does not serve, so the honest
+options are one arrow head placed at the first league pip or an opacity taper along `trace.path`.
+
+### 8
+
+[where] during the outing
+[from] source: `components/session/ExpeditionPanel.tsx`, `stores/expedition.ts`,
+`docs/gameplay/expeditions.md`
+[severity] friction
+[claim] The goal the hero set has no denominator on either surface, so the numerator means nothing
+until it flips a word.
+[evidence] `expeditions.md` refuses a countdown on purpose, "the phone is in a pocket", and the
+panel honours that. But it prints no target either: the panel reads `goal` from the session store
+and passes it only through `goalReached`. So the hero reads "2.40 km" with no way to recall whether
+they asked for four or six, and learns the answer when the status word changes to "Goal met". A
+target is not a countdown; it is the denominator that makes a number mean something at a glance.
+*(Assumes the hero looks, or reads the notification, which is the pocket half of the same fix.)*
+[fix] Print the goal dim beside the leading figure, `"2.40 km / 5 km"`, and give the notification's
+line the same suffix. The value is already a prop of the panel and already in scope in
+`progressLine`'s caller.
+
+### 9
+
+[where] the history row
+[from] shot 20, plus source: `components/journal/SessionCard.tsx`,
+`docs/gameplay/expeditions.md`
+[severity] friction
+[claim] An outing's row prints a difficulty on a walk, while the field that says which way out it
+was is loaded onto the row and read by nothing.
+[evidence] Every row renders `Tag label={t('quests.level_' + entry.userLevel)}`, which is "Hard" or
+"Medium" in shot 20, so a walk is filed next to `5.70 km · 45 min` as Hard. `expeditions.md` is
+explicit that this is not a claim the economy makes: "No target ceiling and no level multiplier, a
+walk is neither easy nor hard." Meanwhile `JournalEntry` carries `outing: Locomotion | null`, the
+column added in 0049, and `SessionCard` never mentions it: walk, run and ride are told apart only
+by the quest's title. This is the "who consumes this value?" rule in AGENTS.md, with the value on
+the near side of the boundary rather than the far side.
+[fix] When `entry.outing !== null`, the level chip becomes the way out: `Walk`, `Run`, `Ride`. One
+ternary, one value already on the row, and it removes a claim the game does not make.
+
+### 10
+
+[where] the recap
+[from] shot 26, plus source: `app/recap.tsx` `traceColor`, `constants/rawColors.ts`
+[severity] friction
+[claim] A stop is painted slate grey on near-black with no mark and no legend entry, which is state
+carried by colour alone and a colour nobody can see.
+[evidence] `traceColor` paints a credited-nothing stretch `rawColors.muted`, `#64748B`, and with
+tiles off the ground is `rawColors.bgDark`. On a screen whose stated design is that "the trace is
+the only lit thing", the stop is the one stretch that is not lit. `SpeedLegend` deliberately gives
+it no swatch, and the file writes down the debt it is taking: "Stops earn a mark on the map before
+they earn a word under it." In shot 26 the only candidate is a few pixels of grey arc beside a
+league pip, at 300 % zoom. PRODUCT.md's accessibility rule is that state never depends on colour
+alone.
+[fix] Pay the debt the comment names: a stop past some duration gets a pip, in the same circle
+vocabulary the league markers already use, hollow where the league is gold-ringed. It is a
+`GeoJSONSource` and a `circle` layer, which is what the other four marks on this map already are.
+
+### 11
+
+[where] during the outing
+[from] source: `components/session/ExpeditionPanel.tsx`
+[severity] polish
+[claim] Three unlabelled figures, two of which trade places depending on a choice the hero made
+before setting off, so the same walk has two different readouts.
+[evidence] `distanceLeads = !acquiring && goal?.type === "distance"` decides which of the clock and
+the distance takes 56 px and which takes 24 px. Neither carries a label; the code's own comment
+defends that for the two-durations case, which was a real problem, and the swap is what it leaves
+behind. So the 24 px slot is a distance on a duration outing and a clock on a distance outing, and
+the pace beside it carries its unit and is therefore the only one of the three that reads on its
+own. *(Assumes the hero looks.)*
+[fix] Label the second figure only, since it is the one whose identity changes. Two words, no
+layout change, and the 56 px figure keeps the silence the comment argues for.
+
+### 12
+
+[where] during the outing
+[from] source: `components/session/ActiveExerciseView.tsx`, `stores/expedition.ts`;
+`docs/design/audits/references.md` findings 3 and 4
+[severity] polish
+[claim] The world says nothing for forty-five minutes: the outing wears the gym session's shell,
+and the only thing that ever changes on it is three numerals.
+[evidence] An outing renders `ExerciseHero` with the movement's static plate, the quest title in a
+12 px HUD row, the panel, an empty middle where the counter is suppressed, and the finish button.
+Nothing in that stack has a second state. The app detects five things while the hero is out and
+none of them mark the screen: the gate opening and the trace breaking change one 13 px word, a stop
+dims the figures to `$textSecondary`, a league crossing writes nothing at all, and the goal changes
+the same 13 px word. references.md finding 4 (Zwift) is the rule this breaks: "the celebration
+happens where the effort happened"; finding 3 (Zombies, Run!) is the shape of the answer, a beat
+placed in the minutes the body is not being asked for anything.
+[fix] Needs a redesign. The league crossing is the beat an outing already has, already detects and
+already vibrates for: let it mark the screen the way a kill marks `VictoryView`, for a breath, in
+the world's register and naming the road it just paid, and let `setProgress` put the same sentence
+on the notification so the hero who never unlocks gets it too. Everything else on the screen keeps
+its silence.
+
+---
+
+## Where to start
+
+1. **Finding 2** is the owner's third complaint in one query. Three columns, one component swap.
+2. **Finding 1** is the owner's second complaint, and the conversion is already written on another
+   screen. Move it into the formatter that claims to own conversions and call it.
+3. **Finding 3** is a rule with two obedient callers and one that is not, in the surface the
+   mandate names. One column and one branch.
+4. **Findings 4, 5 and 8** are the pocket. They are the cheapest changes on the list and they are
+   the ones a hero on the road actually receives.
+5. **Findings 6 and 12** are the owner's first complaint, and neither needs a map, a tile or a
+   dependency. They need the screen to have a second state.
+
+## Not covered
+
+- The live screen has never been photographed. Findings 1, 4, 5, 6, 8, 11 and 12 are readings of
+  source and would each be worth one shot of a real walk before a fix is designed against them.
+- Battery. Findings 1 and 6 add work to a screen the hero is told to put away; both are cheap on
+  paper and neither has been measured on a device.
+- French. `locales/fr.json` carries the same keys and was not read for this pass.

--- a/docs/design/audits/2026-09-10-stats.md
+++ b/docs/design/audits/2026-09-10-stats.md
@@ -1,0 +1,171 @@
+---
+title: Design audit, the stats tab
+type: design
+status: active
+updated: 2026-09-10
+related: [2026-09-10.md, 2026-09-10-regular.md]
+---
+
+# Design audit, the stats tab
+
+Brief, in the owner's words: "les stats ne sont pas tres sympas, a revoir." Seeded hero, roughly
+550 sessions over three years, level 44, English. The regular's findings 1, 5, 6, 11 and 12 are
+taken as given and not repeated; the 100-workout bug is fixed and the tiles are real lifetime
+totals now. Ranked hardest first.
+
+## The verdict, before the findings
+
+**Thirteen blocks mount on this tab.** Streak, lifetime tiles, Recent Activity, Workout Days,
+Difficulty Split, Trends, calendar, level, records, achievements, progression, muscle balance,
+suggested quests. Shots 17, 18 and 19 reach the calendar, which is block seven. The regular
+persona read three screens and reported there were no personal records on this tab; the records
+card is block nine. A card nobody scrolls to is a card that does not exist.
+
+**Which charts show attendance, which show improvement.**
+
+| Chart | Shows |
+| --- | --- |
+| Workout Days histogram | attendance |
+| Trends, Sessions series | attendance |
+| Trends, Minutes series | attendance wearing an effort costume: a prescribed quest that took longer means the hero was slower |
+| Monthly calendar | attendance, and rightly so, that is its job |
+| Difficulty Split bar | a mix with no time axis, so neither |
+| Muscle Balance bars | distribution, the only card that makes a claim instead of a count |
+| Achievements ring | milestones |
+| ProgressionCard, "your next rung" | improvement. The only one. Block eleven. |
+| The XP series | improvement, effort-weighted, computed and discarded (finding 4) |
+
+**Earn their place:** the lifetime tiles (now that they are true), the calendar, TrendsCard once
+its series is XP, PersonalRecordsCard once it stops repeating itself, ProgressionCard,
+AchievementsCard, MuscleBalanceCard.
+
+**Decoration:** Recent Activity (three numbers the calendar and the trend badges already carry,
+and one of them disagrees with the calendar), Workout Days (flat by construction for a consistent
+hero, and reads a different window from its neighbours), UserLevelCard (Home's header restated),
+Difficulty Split as a card of its own (per the regular's finding 12, it is one line or it is a
+time series). SuggestedQuestsCard is not decoration but it is a "what next" at the bottom of a
+"what was" screen; it belongs on Home.
+
+**The order it should be in:** flame, record wall, trends on XP, lifetime tiles, calendar with
+the difficulty mix on it, next rung, achievements, muscle balance. Nine blocks instead of
+thirteen, and something about getting better inside the first screen.
+
+**The one new card:** a record wall, per movement, off `getExerciseHistory`. Best and last in
+each movement's own unit, with the date the best was set. It is the only thing this tab could
+say on a rest day, because it is the only thing here that names something to beat tomorrow.
+
+---
+
+## 1
+
+[where] The tab as a whole, the order the cards mount in
+[from] app/(tabs)/journal/index.tsx, the fragment at the foot of the file; shots 17, 18, 19
+[severity] blocker
+[claim] Six of the first seven blocks answer "did I show up", and the only block that says whether I got better is the eleventh.
+[evidence] Streak, lifetime tiles, Recent Activity, Workout Days, Difficulty Split, Trends, calendar. The streak, Recent Activity, Workout Days, both Trends series and the calendar are all counts of appearances, and three of them count the same week. ProgressionCard's "your next rung, 2 of 3 clean sessions" is the one sentence on the tab about capability, and it sits roughly five screens down. The comment above the fragment states the intended order, "am I consistent, am I progressing, what next", and act one has been allowed to grow to seven cards while act two starts below the fold twice over.
+[fix] Record wall and Trends to positions two and three, Recent Activity and Workout Days cut. A rest day has no attendance to report, which is precisely when the tab needs something else to say.
+
+## 2
+
+[where] PersonalRecordsCard
+[from] components/journal/PersonalRecordsCard.tsx, locales/en.json:660 and :683
+[severity] blocker
+[claim] The only card holding something beatable spends half its tiles restating numbers from cards above it, under the identical English.
+[evidence] `journal.pr_total_sessions` is the string "Total Workouts". `journal.total_workouts` is also the string "Total Workouts". Both render `COUNT(*) WHERE isWorkout()`: the same number, the same words, one screen apart. `pr_best_streak` renders `getStreakInfo().best`, which is the "Best 1092" in the streak card at the very top. That leaves "Longest" and "Most XP" as the only records the card adds, both session-level, both settled years ago for this hero.
+[fix] Delete the two duplicate tiles, fill the card with per-movement records (finding 5), and keep the session-level ones underneath rather than instead.
+
+## 3
+
+[where] The whole tab, its vocabulary
+[from] locales/en.json:660-699; shots 17 and 18
+[severity] blocker
+[claim] This is the one screen in a dark fantasy RPG written in dashboard English, which is the shortest answer to why it is not worth opening.
+[evidence] Total Workouts, Total Minutes, Avg Duration, Recent Activity, This Week, Mins This Week, This Month, Workout Days, Difficulty Split, Your Progress, Sessions, Minutes, Personal Records, Muscle Balance. Home calls the same rows "Quests" (`home.quests_done`), and this tab's own calendar footer already says "Flame days", so the register exists and this screen declines it. The only fantasy in shot 17 is the herbalist cameo, and she is an overlay, not the screen.
+[fix] Rename to nouns the world already owns, no new art and no ornament on any figure: quests rather than workouts, the flame rather than the streak, leagues where ground is meant. The number stays the largest thing in the tile.
+
+## 4
+
+[where] TrendsCard, "Your Progress"
+[from] components/journal/TrendsCard.tsx `loadData`; db/completed.ts `getTrendSummary`; locales/en.json:699, fr.json:481
+[severity] blocker
+[claim] The one series on this tab that is not attendance is already computed, already translated in both languages, and dropped on the floor at the card boundary.
+[evidence] `getTrendSummary()` returns `xpAnalysis`, and every `WeeklyTrend` and `MonthlyTrend` row carries `totalXp`. `TrendsCardComponent` keeps `weeklyTrends`, `monthlyTrends`, `sessionsAnalysis` and `minutesAnalysis`, and never touches the XP. `journal.trends_xp` is "XP Earned" and "XP gagnes", rendered by nothing; `journal.trends_vs_last_week` is the same, orphaned. XP is priced off reps, tempo and difficulty, so it is the only effort-weighted number the journal owns, and the Minutes series it would replace goes up when the hero is slower on a quest of fixed prescription.
+[fix] Swap the Minutes bars for the XP bars and render `xpAnalysis` in the badge row. Query, type and both translations exist; the change is the render.
+
+## 5
+
+[where] The new card, in the space the emptied records card leaves
+[from] db/personalRecords.ts `getExerciseHistory`; db/exercises.ts `allSessionMetFlags`
+[severity] friction
+[claim] The app knows my best and my last on every movement I have ever performed, in that movement's own unit, and says so on every screen except the journal.
+[evidence] `getExerciseHistory` returns `{ last, best, at }` keyed `exerciseId:resultType` in one grouped query, and its `last` is deliberately the best set of the most recent session rather than that session's final row. Its only callers are `app/exercises/[id].tsx` and `db/quests.ts`; nothing under `components/journal/` imports it. `checkForNewRecords` already stamps `exercise_max_reps` and `exercise_max_time` per movement on every save, which is what puts the unlabelled PR chip on the history row in shot 20.
+[fix] A record wall: movements ordered by how recently they moved, each reading "best N reps, set <date>" with the last result beside it. It is the standing value that the history's PR chip never names, and the one thing on this tab that a rest day can act on.
+
+## 6
+
+[where] The lifetime tiles
+[from] components/journal/JournalStats.tsx; shot 17
+[severity] friction
+[claim] A bodyweight RPG counts my lifetime in minutes and never once in reps.
+[evidence] The tiles are workouts, minutes, average duration, and the outing row adds count, ground, average outing. `completedExercises.resultValue` holds every rep and every held second ever logged, and `repEquivalentSql` already folds the two units into one for the village buildings and for boss damage. No tile, chart or sentence on this tab sums them. Minutes are the one currency the hero does not choose: the quest prescribes the work, so its length is mostly the app's decision, not theirs.
+[fix] Replace "Total Minutes" with lifetime reps through the existing `repEquivalentSql`. It is the largest true thing the app knows about this hero, and it is the one they actually did.
+
+## 7
+
+[where] Recent Activity, against the calendar footer
+[from] shots 17 and 19; db/completed.ts `getJournalStats` and `listWorkoutDayKeys`
+[severity] friction
+[claim] Two cards on one tab report September and disagree, and neither says which question it answered.
+[evidence] Recent Activity reads "6 This Month". The calendar footer reads "5 Workout days", above a grid with five green dots the hero can count. `thisMonthCount` counts every row since the 1st, outings included; `listWorkoutDayKeys` counts distinct days under `isWorkout()`. Both are right, both are labelled as though they were the same measurement, and nothing on either card explains the sixth thing.
+[fix] Cut Recent Activity. "This week" is already on the trend badges, "this month" is a calendar the hero can read, and the third number is the flame's job.
+
+## 8
+
+[where] Workout Days, "When you usually train"
+[from] components/journal/JournalStats.tsx `weekdayData`; shot 18
+[severity] friction
+[claim] The histogram is flat for exactly the hero it is aimed at, and it reads a window nothing on the card admits to.
+[evidence] Seven bars between roughly 12 and 18, drawn from the 100 rows `listCompletedSessions(100)` hands the component. A hero who trains almost daily has no favourite weekday by definition, so the card can only draw a shape for someone irregular, and for everyone else it is seven identical bars. Nothing says it covers the last hundred sessions while the tiles a thumb above it say "Total".
+[fix] Cut it. If a weekday shape is worth keeping, it belongs inside the calendar, where the window is a month the hero picked.
+
+## 9
+
+[where] Day one
+[from] shot 50-journal-day-one-stats; app/(tabs)/journal/index.tsx, the tab row is gated on `history.length > 0`
+[severity] friction
+[claim] On day one there is no Stats tab at all, so the first thing this screen teaches is that it has nothing.
+[evidence] The Stats and History buttons render only when `history.length > 0`. Below them the empty branch is a scroll emoji, "No tales yet", "Complete quests to fill your journal" and a button that leaves the screen. The tab already knows the hero's level, their whole achievement shelf, their oath and a flame at zero, none of which needs a logged session to exist.
+[fix] Keep the tab row, and show the shelf: the record wall with its slots named and empty, achievements, and the first flame day waiting. A journal that shows blank pages is a promise; one that shows a button out is a dead end.
+
+## 10
+
+[where] UserLevelCard
+[from] components/journal/UserLevelCard.tsx; shot 01-home-top
+[severity] friction
+[claim] The card is Home's header restated, and it holds the exact numbers Home's own bar is missing.
+[evidence] Level, title, lifetime XP, progress bar. Home's header shows "Level 44 - Divine 44" over a track reading "0%" with no figures on it, and Home's StatsOverview already shows the same lifetime XP. The journal's copy renders `journal.xp_progress`, "{{current}} / {{next}} XP", which is precisely what the regular audit asked Home's bar to say.
+[fix] Move that string to Home's level bar and delete the card here. One writer per value, and the level belongs where the hero starts.
+
+## 11
+
+[where] MonthlyCalendarCard
+[from] shots 18 and 19
+[severity] polish
+[claim] The calendar draws a month and knows nothing about it except that a day was green.
+[evidence] Every dot is the same green whether the day was Easy or Hard, one quest or three, a session or a walk. `completedQuest.userLevel` is per row, and the calendar is the only card on this tab that already owns a time axis, which is the axis the Difficulty Split card has no way to draw.
+[fix] Mark the dot by the hardest difficulty of that day, shape as well as tint so the state never depends on colour alone. That is the split's story with a time axis on it, and it is what lets the split card shrink to the one line it should be.
+
+## 12
+
+[where] The ambient cameo, over the stats scroll
+[from] shot 17, against shot 50
+[severity] polish
+[claim] The villager lands on top of the one card title that explains what its chart means.
+[evidence] In 17 the herbalist covers the left half of the "Workout Days" header: the title reads "W...ays", the subtitle "...ually", and her speech box takes the rest of the row. Shot 50 has the same figure at the same coordinates over an empty screen, so the placement is fixed rather than aware of what is under it.
+[fix] Anchor the cameo to the bottom inset above the tab bar, or hold it until the scroll is at rest. The pact says never on screen longer than a breath. It does not say she may eat a heading.
+
+## Related
+
+- [2026-09-10-regular.md](2026-09-10-regular.md) - the daily trainer's pass over the same tab
+- [references.md](references.md) - Hevy per-movement PRs (1), Strava best efforts (2), Hevy ghost numbers (7), the monthly chronicle (11)
+- [../../gameplay/statistics-progress.md](../../gameplay/statistics-progress.md) - what this screen is specified to be

--- a/docs/design/audits/2026-09-10.md
+++ b/docs/design/audits/2026-09-10.md
@@ -240,6 +240,19 @@ by the same flow, and the same four personas judge before against after.
 12. The expedition recap pays in leagues and says what they moved, above the distance and the
     pace. The tile-server paragraph goes behind the button it is actually about.
 
+## 6b. Three surfaces audited on their own
+
+The owner named three places that felt wrong and asked for a designer's pass on each. They read
+the same shots, plus the source of the screens no screenshot covers, and each marks which of its
+findings came from code rather than from a picture.
+
+- [Starting a session, and setting up an outing](2026-09-10-home-and-outings.md) - the number of
+  moves between opening the app and being under way, for a quest and for a walk.
+- [The outing and its trace](2026-09-10-outings.md) - what the hero sees while moving, what the
+  phone already knows and does not show, and where the drawing of the route stops.
+- [The stats tab](2026-09-10-stats.md) - which cards earn their place, in what order, and what the
+  existing data would already support.
+
 ## 7. Not covered
 
 - `13-quest-editor.png` caught the Expo dev menu instead of the editor, so the quest editor is

--- a/locales/en.json
+++ b/locales/en.json
@@ -695,7 +695,6 @@
     "trends_weekly": "Weekly",
     "trends_monthly": "Monthly",
     "trends_sessions": "Sessions",
-    "trends_minutes": "Minutes",
     "trends_xp": "XP Earned",
     "trends_vs_last_week": "vs last week",
     "trends_up": "↑ {{change}}%",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -469,7 +469,6 @@
     "total_workouts": "Entraînements totaux",
     "total_xp": "XP total",
     "trends_down": "↓ {{change}}%",
-    "trends_minutes": "Minutes",
     "trends_monthly": "Mensuel",
     "trends_no_data": "Entraîne-toi plus pour voir les tendances",
     "trends_sessions": "Séances",

--- a/stores/expedition.ts
+++ b/stores/expedition.ts
@@ -65,6 +65,20 @@ type ExpeditionState = {
   /** The most recent accepted fix, for an accuracy readout. */
   lastFix: LocationFix | null;
   /**
+   * How fast the hero is going *now*, in metres per second, meaned over the last twenty seconds.
+   * Null until the window has something in it.
+   *
+   * The receiver reports a speed on every fix, once a second, and until 2026-09-11 the only
+   * figure the panel could print was the whole outing's average, which a hard four hundred metres
+   * moves by six seconds per kilometre after an hour. So the screen answered "how fast has this
+   * walk been" to a hero asking "how fast am I going".
+   *
+   * Meaned rather than raw: a single fix's speed jitters by a metre per second on a good
+   * receiver, and a figure that flickers is one nobody reads. Twenty seconds is the window
+   * `src/gps/trace.ts` already chose against a real device for the same reason.
+   */
+  recentSpeedMps: number | null;
+  /**
    * Why the readout is not moving, in a code the panel turns into words: the service refused to
    * start, the hero denied the prompt, or the trace went quiet mid-walk (`gps-off`, `no-fix`).
    * The last two are transient and clear themselves the moment fixes come back.
@@ -113,6 +127,24 @@ let progressTimer: ReturnType<typeof setInterval> | null = null;
  * Whole leagues already announced, a high-water mark rather than a count. Seeded by `begin()`.
  */
 let leaguesCrossed = 0;
+
+/** The last `SPEED_WINDOW_MS` of reported speeds, newest last. Cleared with the buffer. */
+let speedWindow: { t: number; v: number }[] = [];
+
+/** Same twenty seconds `src/gps/trace.ts` smooths over, and for the same receiver. */
+const SPEED_WINDOW_MS = 20_000;
+
+/**
+ * The mean of what the receiver reported over the window, or null when it reported nothing.
+ *
+ * A fix with no speed is not a fix at zero: some receivers omit the field entirely, and counting
+ * those as stopped drags the mean towards a standstill the hero is not at.
+ */
+function meanSpeed(now: number): number | null {
+  speedWindow = speedWindow.filter((s) => now - s.t <= SPEED_WINDOW_MS);
+  if (speedWindow.length === 0) return null;
+  return speedWindow.reduce((sum, s) => sum + s.v, 0) / speedWindow.length;
+}
 
 /** Whole leagues in a reading. The only place the counter and the recap agree by construction. */
 function leaguesOf(track: TrackState): number {
@@ -208,6 +240,7 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
   sessionUuid: null,
   track: EMPTY,
   lastFix: null,
+  recentSpeedMps: null,
   error: null,
   goalReached: false,
 
@@ -221,8 +254,9 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
       .catch((e) => reportError("expedition.restart", e));
     buffer = [];
     leaguesCrossed = 0;
+    speedWindow = [];
     acquiringWord = notification.acquiring;
-    set({ track: EMPTY, lastFix: null, error: null, goalReached: false });
+    set({ track: EMPTY, lastFix: null, recentSpeedMps: null, error: null, goalReached: false });
 
     if (!isAvailable()) {
       // No native half: iOS today, and jest. The quest still runs, it just measures nothing.
@@ -281,10 +315,17 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
     subscriptions = [
       addListener("onLocation", (fix) => {
         buffer.push(fix);
+        if (fix.speed != null) speedWindow.push({ t: fix.t, v: fix.speed });
         const track = accept(get().track, fix);
         const wasReached = get().goalReached;
         const reached = wasReached || goalReached(goal, track);
-        set({ track, lastFix: fix, goalReached: reached, error: clearedTransient(get().error) });
+        set({
+          track,
+          lastFix: fix,
+          recentSpeedMps: meanSpeed(fix.t),
+          goalReached: reached,
+          error: clearedTransient(get().error),
+        });
 
         if (reached && !wasReached) announceGoalReached(track, unit, haptics);
         announceLeague(track, haptics);

--- a/stores/session.ts
+++ b/stores/session.ts
@@ -1021,6 +1021,25 @@ export const useSessionStore = create<SessionState>()(
     triumphBonusPaid: false,
 
     startSession: async (quest, userLevel, options) => {
+      /**
+       * Never over a live one.
+       *
+       * A session that is neither idle nor finished holds a `sessionUuid`, and on an outing that
+       * name is what every GPS fix written so far is filed under. Overwriting it mints a fresh
+       * uuid and orphans the lot, which is a walk deleted without being asked.
+       *
+       * The guard used to live in `OutsideBand`, on the one-tap door only, with the reason
+       * written next to it. The other door, "Set up", went through the quest screen instead,
+       * whose only guard is against a double tap, so the hero most likely to have a walk paused,
+       * the one going back to change its goal, was the one who lost it. It belongs here, where
+       * every caller routes through.
+       *
+       * Returning without touching the store is the whole refusal: each caller pushes
+       * `/session` next, which is where a live session already is.
+       */
+      const live = get().status;
+      if (live !== "idle" && live !== "finished") return;
+
       // Load boss fight if this is a boss adventure. Callers only ever hold the run step id —
       // it is what the adventure screen puts in the URL and what the victory screen chains to —
       // so resolve the adventure here rather than threading a second param through three


### PR DESCRIPTION
Four findings from yesterday's design audits, each small, each with the test it
was missing. The audits themselves are in `docs/design/audits/`.

**The session detail learns that outings exist.** `getCompletedSessionById`
selected nine columns and none of them were `leaguesM`, `movingSeconds` or
`outing`, though `listCompletedSessions` in the same file has always selected
all three. So the one screen between a walk's history row and its map printed
it as a dumbbell exercise that lasted 45 minutes. The ground now sits beside
the duration, and the door to the map draws the run's own line instead of a map
pin: the points were one query away and the screen was already making it.

**A session never starts over a live one.** `startSession` mints a fresh
`sessionUuid`, which on an outing is what every GPS fix so far is filed under.
The guard existed on one door only, the Home tile; the other door goes through
the quest screen, so the hero most likely to have a walk paused, the one going
back to change its goal, was the one who lost it.

**The panel says how fast the hero is going.** The receiver reports a speed
every second, and the only figure on screen was the whole outing's average,
which after an hour a hard 400 m moves by six seconds per kilometre. It now
means the last twenty seconds, the window `src/gps/trace.ts` already chose
against a real receiver.

**Your Progress shows what the effort was worth.** `xpAnalysis` and `totalXp`
were computed, translated in both languages, and dropped at the card boundary.
XP replaces minutes rather than joining them: on a quest of fixed prescription,
minutes go up when the hero is slower.

`journal.trends_minutes` and `hasPoints` go with them, so the change pays the
dead-code debt rather than trading it.

140 suites, 1581 tests, `tsc`, `biome --error-on-warnings` and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP