### PR TITLE
The way out keeps its distance, and the drawn line stops where the run stopped

### DIFF
--- a/__tests__/db-quest-config.test.ts
+++ b/__tests__/db-quest-config.test.ts
@@ -292,6 +292,32 @@ describe("db/questConfig", () => {
    * This exercises Home's path (`loadConfiguredQuest`) against the real seeded database, which is
    * the only way to catch the catalogue never being threaded in.
    */
+  /**
+   * A distance goal is the one choice that is not a slot: `applyQuestConfig` folds every other
+   * one into the quest it returns, and this one lives beside them. It was read and dropped, so
+   * the tile on Home started every walk with no number on it while the sheet that saved the
+   * distance promised it would come back.
+   */
+  test("Home's path carries the distance the hero saved, not only the shaped quest", async () => {
+    const outings = require("../db/outings") as typeof import("../db/outings");
+    const expeditions = require("../db/expeditions") as typeof import("../db/expeditions");
+
+    // A real door out, from the same list Home's band reads.
+    const [door] = await outings.listOutings();
+    assert(door);
+
+    await saveQuestConfig(door.quest.id, { level: Difficulty.Medium, distanceM: 10_000 });
+
+    const loaded = await loadConfiguredQuest(door.quest.id, Difficulty.Medium);
+    assert(loaded);
+    expect(loaded.config?.distanceM).toBe(10_000);
+    // And what Home does with it: the goal the hero set, not the slot's duration.
+    expect(expeditions.outingGoal(loaded.quest, loaded.config?.distanceM ?? null)).toEqual({
+      type: "distance",
+      metres: 10_000,
+    });
+  });
+
   test("Home's path starts the movement the hero swapped in", async () => {
     const quests = require("../db/quests") as typeof import("../db/quests");
     const exercisesDb = require("../db/exercises") as typeof import("../db/exercises");

--- a/__tests__/trace-preview.test.ts
+++ b/__tests__/trace-preview.test.ts
@@ -20,13 +20,15 @@ function coords(d: string): [number, number][] {
 describe("traceToPath", () => {
   test("a run with nothing to draw draws nothing", () => {
     expect(traceToPath([], 50)).toBeNull();
-    expect(traceToPath([[2.35, 48.85]], 50)).toBeNull();
+    expect(traceToPath([[[2.35, 48.85]]], 50)).toBeNull();
     // Every fix inside the receiver's noise, all on one spot: a real row with no shape.
     expect(
       traceToPath(
         [
-          [2.35, 48.85],
-          [2.35, 48.85],
+          [
+            [2.35, 48.85],
+            [2.35, 48.85],
+          ],
         ],
         50,
       ),
@@ -41,7 +43,7 @@ describe("traceToPath", () => {
       [2.355, 48.845],
     ];
 
-    for (const [x, y] of coords(traceToPath(points, 50) ?? "")) {
+    for (const [x, y] of coords(traceToPath([points], 50) ?? "")) {
       expect(x).toBeGreaterThanOrEqual(4);
       expect(x).toBeLessThanOrEqual(46);
       expect(y).toBeGreaterThanOrEqual(4);
@@ -49,11 +51,40 @@ describe("traceToPath", () => {
     }
   });
 
+  /**
+   * The gap is the point. `src/gps/trace.ts` breaks its line wherever `breaksRun` says the run
+   * broke, and a thumbnail that drew one unbroken chain across the same hole told the hero they
+   * went through the tunnel. One `M` per stretch, and the bounds still span all of them so the
+   * two halves of a run stay in scale with each other.
+   */
+  test("lifts the pen between two stretches instead of drawing through the hole", () => {
+    const d =
+      traceToPath(
+        [
+          [
+            [2.35, 48.85],
+            [2.351, 48.851],
+          ],
+          [
+            [2.36, 48.86],
+            [2.361, 48.861],
+          ],
+        ],
+        100,
+      ) ?? "";
+
+    // Two moves, two lines: the second stretch starts a new subpath rather than continuing.
+    expect(d.match(/M/g)?.length).toBe(2);
+    expect(d.match(/L/g)?.length).toBe(2);
+  });
+
   test("north is up, because SVG's y is not latitude's", () => {
     const d = traceToPath(
       [
-        [2.35, 48.85],
-        [2.35001, 48.86],
+        [
+          [2.35, 48.85],
+          [2.35001, 48.86],
+        ],
       ],
       50,
     );
@@ -79,7 +110,7 @@ describe("traceToPath", () => {
       [2, lat],
     ];
 
-    const drawn = coords(traceToPath(square, 100) ?? "");
+    const drawn = coords(traceToPath([square], 100) ?? "");
     const width = Math.max(...drawn.map(([x]) => x)) - Math.min(...drawn.map(([x]) => x));
     const height = Math.max(...drawn.map(([, y]) => y)) - Math.min(...drawn.map(([, y]) => y));
 
@@ -93,8 +124,10 @@ describe("traceToPath", () => {
     const drawn = coords(
       traceToPath(
         [
-          [2, lat],
-          [2 + dLon, lat + 0.002],
+          [
+            [2, lat],
+            [2 + dLon, lat + 0.002],
+          ],
         ],
         100,
       ) ?? "",

--- a/app/(tabs)/journal/[id].tsx
+++ b/app/(tabs)/journal/[id].tsx
@@ -23,11 +23,11 @@ import { formatDuration, getCompletedSessionById } from "@/db";
 import type { CompletedSession } from "@/db/completed";
 import { EQUIPMENT_LABELS } from "@/db/equipment";
 import { hasGround } from "@/db/expeditions";
-import { previewPathsFor } from "@/db/gps";
+import { pointsOf } from "@/db/gps";
 import { MUSCLE_LABELS } from "@/db/muscles";
 import { getCached, setCached } from "@/db/queryCache";
 import { listQuestTemplates } from "@/db/quests";
-import type { LngLat } from "@/src/gps/trace";
+import { type LngLat, toTrace } from "@/src/gps/trace";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useSettingsStore } from "@/stores/settings";
@@ -48,13 +48,18 @@ const parseId = (raw?: string | string[]): number | null => {
  * the hero had been outside. Never allowed to fail the screen either: a missing trace is not
  * worth losing the session over, and a swallowed failure is not allowed.
  */
-async function traceFor(uuid: string | null): Promise<readonly LngLat[]> {
+async function traceFor(uuid: string | null): Promise<readonly (readonly LngLat[])[]> {
   if (!uuid) return [];
-  const paths = await previewPathsFor([uuid]).catch((error) => {
+  const fixes = await pointsOf(uuid).catch((error) => {
     reportError("journal.trace", error);
-    return null;
+    return [];
   });
-  return paths?.get(uuid) ?? [];
+  if (fixes.length < 2) return [];
+  // `toTrace` is what the recap draws from, and its `path` is already one part per unbroken run.
+  // Going through it rather than through `previewPathsFor` is what puts the gaps in: the preview
+  // query downsamples and drops the clock, so it cannot know where the reducer stopped counting,
+  // and a thumbnail built from it runs a straight gold line through the tunnel.
+  return toTrace(fixes).path.geometry.coordinates as LngLat[][];
 }
 
 export default function SessionDetailScreen() {
@@ -75,7 +80,7 @@ export default function SessionDetailScreen() {
   );
   // Whether this session left a trace. Every strength quest has none, and a door onto an empty
   // map is worse than no door — see app/recap.tsx.
-  const [trace, setTrace] = useState<readonly LngLat[]>([]);
+  const [trace, setTrace] = useState<readonly (readonly LngLat[])[]>([]);
   const [questTitle, setQuestTitle] = useState<string>(() =>
     sessionId != null ? (getCached<string>(`sessionTitle:${sessionId}:${language}`) ?? "") : "",
   );
@@ -291,7 +296,7 @@ export default function SessionDetailScreen() {
                     {/* The run's own shape, not a map pin: the trace is already loaded and the
                         door might as well show what is behind it. Same drawing and same gold as
                         the history row this screen was tapped from. */}
-                    <TraceThumb points={trace} size={56} />
+                    <TraceThumb segments={trace} size={56} />
                     <YStack flex={1} gap="$1">
                       <Text fontWeight="700" fontSize={16} color="$text">
                         {t("recap.open", "See the ground covered")}

--- a/components/home/OutsideBand.tsx
+++ b/components/home/OutsideBand.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from "@/components/common/Skeleton";
 import { Play, SlidersHorizontal } from "@/components/icons";
 import { getQuestThumb } from "@/constants/assetMap";
 import { rawColors } from "@/constants/rawColors";
+import { outingGoal } from "@/db/expeditions";
 import { listOutings, type Outing } from "@/db/outings";
 import { loadConfiguredQuest } from "@/db/questConfig";
 import { Difficulty } from "@/db/targets";
@@ -210,7 +211,15 @@ export function OutsideBand() {
 
         // Awaited on purpose: `startSession` loads the boss fight and the warm-up preference
         // before it populates the store, and the session screen redirects home on an empty one.
-        await startSession(loaded.quest, loaded.level, { goal: null });
+        //
+        // The goal is the hero's own, when they set one. This used to be a hard-coded `null`,
+        // while the sheet that saved the distance promised "Saved for this quest. It comes back
+        // next time": it did not, and the five taps of the setup flow had to be walked again on
+        // every way out. `outingGoal` falls back to the slot's duration, which is what "no number
+        // on it" has always meant here.
+        await startSession(loaded.quest, loaded.level, {
+          goal: outingGoal(loaded.quest, loaded.config?.distanceM ?? null),
+        });
         router.push("/session" as never);
       } catch (error) {
         setIsStarting(false);

--- a/components/journal/SessionCard.tsx
+++ b/components/journal/SessionCard.tsx
@@ -95,8 +95,10 @@ export const SessionCard = memo(function SessionCard({ entry, onPressEntry }: Se
           {/* The run itself, when there is one. The three seeded outings share three pictures, so
               a page of walks was a column of identical thumbnails - the same complaint the
               trophy below records, one row further in. A line is never the same twice. */}
+          {/* One segment: `previewPathsFor` downsamples and drops the clock, so a row cannot know
+              where the run broke. The detail screen behind it draws the real stretches. */}
           {entry.tracePoints.length > 1 ? (
-            <TraceThumb points={entry.tracePoints} size={50} />
+            <TraceThumb segments={[entry.tracePoints]} size={50} />
           ) : entry.cover ? (
             <Image
               source={entry.cover}

--- a/components/journal/TraceThumb.tsx
+++ b/components/journal/TraceThumb.tsx
@@ -16,13 +16,14 @@ import { traceToPath } from "./tracePreview";
  * shape of a run needs no tiles under it.
  */
 export const TraceThumb = memo(function TraceThumb({
-  points,
+  segments,
   size,
 }: {
-  points: readonly LngLat[];
+  /** One entry per unbroken stretch. A list row that has only the line passes `[points]`. */
+  segments: readonly (readonly LngLat[])[];
   size: number;
 }) {
-  const d = traceToPath(points, size);
+  const d = traceToPath(segments, size);
   if (d === null) return null;
 
   return (

--- a/components/journal/tracePreview.ts
+++ b/components/journal/tracePreview.ts
@@ -18,7 +18,12 @@ import type { LngLat } from "@/src/gps/trace";
  * Pure, and given `size` rather than reading a layout: the caller draws it into a `viewBox`, so
  * this never needs to know the density it lands on.
  */
-export function traceToPath(points: readonly LngLat[], size: number, padding = 4): string | null {
+export function traceToPath(
+  segments: readonly (readonly LngLat[])[],
+  size: number,
+  padding = 4,
+): string | null {
+  const points = segments.flat();
   if (points.length < 2) return null;
 
   const lats = points.map(([, lat]) => lat);
@@ -44,13 +49,25 @@ export function traceToPath(points: readonly LngLat[], size: number, padding = 4
   const offsetX = padding + (box - spanX * scale) / 2;
   const offsetY = padding + (box - spanY * scale) / 2;
 
-  return points
-    .map(([lon, lat], i) => {
-      const x = offsetX + (lon * kx - minX) * scale;
-      // SVG's y grows downwards and latitude grows north, so the axis is flipped here rather
-      // than by a transform on the element: a path nobody has to read a matrix to understand.
-      const y = offsetY + (spanY - (lat - minY)) * scale;
-      return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
-    })
+  // One `M` per segment, never a single chain.
+  //
+  // A segment is a stretch the reducer was willing to credit, and the space between two of them
+  // is a tunnel, a dead battery or a phone that lost the sky. Drawing straight through it is the
+  // exact failure `src/gps/trace.ts` documents at the top of its own file: the picture then tells
+  // the hero they went through the hill. The caller does the breaking, because `breaksRun` is the
+  // one rule that decides it and this file is a renderer.
+  return segments
+    .filter((segment) => segment.length > 0)
+    .map((segment) =>
+      segment
+        .map(([lon, lat], i) => {
+          const x = offsetX + (lon * kx - minX) * scale;
+          // SVG's y grows downwards and latitude grows north, so the axis is flipped here rather
+          // than by a transform on the element: a path nobody has to read a matrix to understand.
+          const y = offsetY + (spanY - (lat - minY)) * scale;
+          return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+        })
+        .join(" "),
+    )
     .join(" ");
 }

--- a/db/questConfig.ts
+++ b/db/questConfig.ts
@@ -306,7 +306,7 @@ export function applyConfigToSlots(
 export async function loadConfiguredQuest(
   questId: number,
   level?: UserLevel,
-): Promise<{ quest: Quest; level: UserLevel } | null> {
+): Promise<{ quest: Quest; level: UserLevel; config: QuestConfig | null } | null> {
   // `listExercises()` is promise-cached, so the catalogue is free after the first read anywhere
   // in the app — and it is what lets a swap resolve without this function knowing about screens.
   const [saved, exercises] = await Promise.all([getQuestConfig(questId), listExercises()]);
@@ -318,5 +318,11 @@ export async function loadConfiguredQuest(
   return {
     quest: applyQuestConfig(quest, config, indexExercises(exercises)),
     level: effective,
+    // The config itself, not only the quest it shaped. `applyQuestConfig` folds the hero's
+    // choices into the slots, and a distance goal is the one choice that is *not* a slot: it
+    // lives beside them, and it was read here and dropped on the floor. So the tile on Home
+    // started every walk with `goal: null` while the screen that saved the distance said, in its
+    // own hint, "Saved for this quest. It comes back next time."
+    config,
   };
 }


### PR DESCRIPTION
Two findings from the design audits of 2026-09-10, both about an outing being
described by something other than what happened.

**The goal the hero saved.** `OutingGoalSheet` saves a distance and tells them,
in its own hint, "Saved for this quest. It comes back next time." The tile on
Home then called `startSession(..., { goal: null })` with the null hard-coded,
so the five-tap setup flow had to be walked again on every way out.
`loadConfiguredQuest` was reading that config already and dropping it; it
returns it now, because a distance goal is the one choice `applyQuestConfig`
cannot fold into the quest. (home-and-outings audit, finding 1)

**The gaps.** `src/gps/trace.ts` opens with the rule and names its three
callers: the reducer refuses to credit a jump in space or a hole in time, and a
picture that draws a straight line across the gap tells the hero they went
through it. `traceToPath` was a fourth caller that had never heard of it.

It takes stretches now, one `M` each, bounds still spanning all of them. The
session detail feeds it the real ones through `toTrace`, which is what the recap
on the next screen already draws from. The history row cannot: `previewPathsFor`
downsamples and drops the clock, so a row has no way to know where the run
broke. It passes its line as one stretch and says so. (outings audit, finding 3)

140 suites, 1584 tests, `tsc`, `biome --error-on-warnings` and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP