### PR TITLE
A walk has no record to beat

### DIFF
--- a/__tests__/db-personalRecords.test.ts
+++ b/__tests__/db-personalRecords.test.ts
@@ -153,6 +153,31 @@ describe("db/personalRecords", () => {
     expect(records[1]).toMatchObject({ type: "time", best: 40, last: 40 });
   });
 
+  test("getMovementRecords leaves outings out, they have no record to beat", async () => {
+    const { getMovementRecords } =
+      require("../db/personalRecords") as typeof import("../db/personalRecords");
+    const now = Math.floor(Date.now() / 1000);
+    const walk = t.sqlite
+      .prepare("SELECT id FROM exercises WHERE style = 'expedition' ORDER BY id LIMIT 1")
+      .get() as { id: number } | undefined;
+    const lift = t.sqlite
+      .prepare("SELECT id FROM exercises WHERE style != 'expedition' ORDER BY id LIMIT 1")
+      .get() as { id: number };
+    assert(walk);
+
+    t.sqlite.exec(`
+      INSERT INTO completed_sessions (id, performedAt) VALUES (1, ${now});
+      INSERT INTO completed_exercises (sessionId, exerciseId, resultType, resultValue, performedAt, sortOrder) VALUES
+        (1, ${walk.id}, 'time', 1982, ${now}, 0),
+        (1, ${lift.id}, 'reps', 10, ${now}, 1);
+    `);
+
+    // "Warden's Walk, 1982s" is the seconds a walk happened to last, not a number anyone set out
+    // to beat. The session screen keeps its ghost line off an outing for the same reason.
+    const records = await getMovementRecords();
+    expect(records.map((r) => r.exerciseId)).toEqual([lift.id]);
+  });
+
   test("getMovementRecords keeps a movement's reps and its holds apart", async () => {
     const { getMovementRecords } =
       require("../db/personalRecords") as typeof import("../db/personalRecords");

--- a/db/personalRecords.ts
+++ b/db/personalRecords.ts
@@ -1,9 +1,10 @@
-import { and, desc, eq, inArray, max, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, max, ne, sql } from "drizzle-orm";
 import { db, schema } from "./client";
 import { isWorkout } from "./completed";
 import { hasGround } from "./expeditions";
 import { totalLeaguesM } from "./gps";
 import type { QuestTargetType } from "./schema";
+import { NON_REP_STYLE } from "./workUnits";
 
 const { completedQuest, completedExercises, exercises } = schema;
 
@@ -253,6 +254,10 @@ export async function getMovementRecords(limit = 6): Promise<MovementRecord[]> {
     })
     .from(completedExercises)
     .innerJoin(exercises, eq(exercises.id, completedExercises.exerciseId))
+    // Never an outing. A walk's "record" is the seconds it happened to last, which is not a
+    // number anyone set out to beat: it is the same reason the session screen keeps its ghost
+    // line off an outing rather than printing "last time 900s" under a panel measuring ground.
+    .where(ne(exercises.style, NON_REP_STYLE))
     .groupBy(completedExercises.exerciseId, completedExercises.resultType)
     .orderBy(desc(max(completedExercises.performedAt)))
     .limit(limit);


### PR DESCRIPTION
The record wall shipped this morning in #76 and the first thing it said on a
device was "Warden's Walk, 1982s". That is the number of seconds a walk happened
to last, and nobody set out to beat it: the session screen already keeps its
"last time" line off an outing for exactly this reason, rather than printing
"last time 900s" under a panel that measures ground.

Outings are out of the query now. Their ground stays in the card, in kilometres,
where the two tiles about walking already were.

Found by looking at it on the phone. The unit tests could not have: they seed
rows directly, and a seeded row has whatever style the fixture gave it.

140 suites, 1597 tests, `tsc`, `biome --error-on-warnings` and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP