### PR TITLE
The recap says what the ground moved, above what the ground was

### DIFF
--- a/__tests__/expedition-recap.test.tsx
+++ b/__tests__/expedition-recap.test.tsx
@@ -32,6 +32,9 @@ jest.mock("@/db/gps", () => ({
 }));
 jest.mock("@/db/quests", () => ({ listQuestTemplates: () => mockQuestTemplates() }));
 jest.mock("@/db/client", () => ({ db: {}, schema: {}, runMigrations: jest.fn() }));
+// The recap names what the leagues moved now, which is one read of the village. These tests are
+// about the map and its numbers, so the road is simply absent and the line draws nothing.
+jest.mock("@/db/village", () => ({ getVillageBuildings: jest.fn().mockResolvedValue([]) }));
 jest.mock("@/db", () => ({ preferences: { setMapTilesEnabled: jest.fn() } }));
 
 // The real i18n, not a stub: this screen's strings live in `locales/*.json` and the inline
@@ -216,6 +219,28 @@ beforeEach(() => {
 describe("a session that left the walls", () => {
   beforeEach(() => {
     mockPointsOf.mockResolvedValue(walkThenStand());
+  });
+
+  /**
+   * Leagues are the one currency nothing else in this game earns, and the road is what they
+   * raise. The screen used to print distance, moving time and pace, which is what every other
+   * running app pays in, and name neither.
+   */
+  test("says what the ground moved, above what the ground was", async () => {
+    const village = require("@/db/village") as { getVillageBuildings: jest.Mock };
+    village.getVillageBuildings.mockResolvedValueOnce([
+      {
+        code: "high_road",
+        enName: "High Road",
+        frName: "Grand-Route",
+        metricValue: 12,
+        nextTarget: 20,
+      },
+    ]);
+
+    await mount();
+
+    expect(await screen.findByText(/High Road/)).toBeTruthy();
   });
 
   test("draws the map and the three numbers", async () => {

--- a/app/recap.tsx
+++ b/app/recap.tsx
@@ -18,6 +18,7 @@ import { Figure } from "@/components/common/Figure";
 import { Skeleton } from "@/components/common/Skeleton";
 import { useToast } from "@/components/common/Toast";
 import { ChevronLeft, Share2 } from "@/components/icons";
+import { roadLine } from "@/components/session/roadLine";
 import { getDateTimeFormat } from "@/constants/dateFormatters";
 import {
   formatClock,
@@ -30,10 +31,12 @@ import { rawColors } from "@/constants/rawColors";
 import { outingSession, pointsOf } from "@/db/gps";
 import type { DistanceUnit } from "@/db/preferences";
 import { listQuestTemplates } from "@/db/quests";
+import { getVillageBuildings, type VillageBuilding } from "@/db/village";
 import type { LocationFix } from "@/modules/bati-location";
 import { toTrace } from "@/src/gps/trace";
 import { accept, EMPTY } from "@/src/gps/track";
 import { flushTrack, shareTrack, trackFileFor } from "@/src/gps/trackFile";
+import type { AppLanguage } from "@/src/i18n/deviceLanguage";
 import { localizedTitle } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useSettingsStore } from "@/stores/settings";
@@ -270,6 +273,44 @@ function MapFootnote({ enabled, onEnable }: { enabled: boolean; onEnable: () => 
   );
 }
 
+/**
+ * The High Road, as it stands now.
+ *
+ * The same read the victory screen makes, for the same sentence: leagues are the one currency
+ * nothing else in this game earns, and the road is what they raise. A recap that printed
+ * distance, moving time and pace and never named either was paying the hero in another app's
+ * currency. Null is a quieter screen, never a failed one.
+ */
+/**
+ * What the ground moved, above what the ground was.
+ *
+ * Gold, because it is a reward and this app has one colour for those. Its own component so the
+ * screen keeps one branch fewer: a road that has not loaded draws nothing, and that is this
+ * function's business rather than the screen's.
+ */
+function RoadLine({ road, language }: { road: VillageBuilding | null; language: AppLanguage }) {
+  const { t } = useTranslation();
+  if (!road) return null;
+
+  return (
+    <Text fontSize={14} fontWeight="700" color="$resourceGold">
+      {roadLine(road, language, t)}
+    </Text>
+  );
+}
+
+function useHighRoad(): VillageBuilding | null {
+  const [road, setRoad] = useState<VillageBuilding | null>(null);
+
+  useEffect(() => {
+    getVillageBuildings()
+      .then((buildings) => setRoad(buildings.find((b) => b.code === "high_road") ?? null))
+      .catch((error) => reportError("recap.road", error));
+  }, []);
+
+  return road;
+}
+
 export default function ExpeditionRecapScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -288,6 +329,7 @@ export default function ExpeditionRecapScreen() {
   // `null` while the read is still on its way. A recap with no fixes is an answer — "this quest
   // never left the walls" — and the two must not render the same thing.
   const [recap, setRecap] = useState<Recap | null>(null);
+  const road = useHighRoad();
 
   const load = useCallback(
     async (uuid: string) => {
@@ -588,6 +630,14 @@ export default function ExpeditionRecapScreen() {
         {/* No guard for "this quest never left the walls": a run with no fixes has no ramp and
             no best league, and the legend already draws nothing when it has nothing to say. */}
         <SpeedLegend range={trace.speedRange} best={trace.bestLeague} unit={distanceUnit} />
+
+        {/* What the ground moved, above what the ground was.
+            This screen used to open on distance, moving time and pace, which is what every other
+            running app pays in. Leagues are the one currency nothing else in this game earns, and
+            they raise the road out of the village: the word appeared once here, as a unit on a
+            pace figure, and the village was not mentioned at all. Same sentence the victory
+            screen prints, from the same query, so the two agree on what a walk bought. */}
+        <RoadLine road={road} language={language} />
 
         {recap?.leaguesM ? (
           <Figures

--- a/components/session/ExpeditionSummary.tsx
+++ b/components/session/ExpeditionSummary.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from "expo-router";
-import type { TFunction } from "i18next";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Text, XStack } from "tamagui";
@@ -8,10 +7,10 @@ import { Figure } from "@/components/common/Figure";
 import { ChevronRight, Map as MapIcon } from "@/components/icons";
 import { formatClock, formatDistance, formatPace } from "@/constants/distanceFormat";
 import { getVillageBuildings, type VillageBuilding } from "@/db/village";
-import { localizedName } from "@/src/i18n/localized";
 import { reportError } from "@/src/reportError";
 import { useExpeditionStore } from "@/stores/expedition";
 import { type AppLanguage, useSettingsStore } from "@/stores/settings";
+import { roadLine } from "./roadLine";
 
 /**
  * What the walk was worth, said on the screen that celebrates it.
@@ -25,26 +24,6 @@ import { type AppLanguage, useSettingsStore } from "@/stores/settings";
  * `track` — so this is the same distance and the same moving time `saveSession` paid the road
  * and the XP from. Summing `gps_points` here would be a third answer to "how far did I go".
  */
-
-/**
- * The one line about the High Road, in the two shapes the road can be in.
- *
- * A road still climbing reads as a fraction of its next floor. A maxed one has no floor left,
- * and `nextTarget` is null there — printing "42/null leagues" is the bug this exists to avoid,
- * so the maxed road borrows the village sheet's own sentence for the same driver rather than
- * inventing a fifteenth way to say "leagues covered".
- */
-function roadLine(road: VillageBuilding, language: AppLanguage, t: TFunction): string {
-  const building = localizedName(road, language);
-  if (road.nextTarget === null) {
-    return `${building} · ${t("village.detail_leagues_driver", { count: road.metricValue })}`;
-  }
-  return t("session.expedition_road", {
-    building,
-    value: road.metricValue,
-    target: road.nextTarget,
-  });
-}
 
 export function ExpeditionSummary({
   sessionUuid,

--- a/components/session/roadLine.ts
+++ b/components/session/roadLine.ts
@@ -1,0 +1,24 @@
+import type { TFunction } from "i18next";
+import type { VillageBuilding } from "@/db/village";
+import type { AppLanguage } from "@/src/i18n/deviceLanguage";
+import { localizedName } from "@/src/i18n/localized";
+
+/**
+ * The one line about the High Road, in the two shapes the road can be in.
+ *
+ * A road still climbing reads as a fraction of its next floor. A maxed one has no floor left,
+ * and `nextTarget` is null there — printing "42/null leagues" is the bug this exists to avoid,
+ * so the maxed road borrows the village sheet's own sentence for the same driver rather than
+ * inventing a fifteenth way to say "leagues covered".
+ */
+export function roadLine(road: VillageBuilding, language: AppLanguage, t: TFunction): string {
+  const building = localizedName(road, language);
+  if (road.nextTarget === null) {
+    return `${building} · ${t("village.detail_leagues_driver", { count: road.metricValue })}`;
+  }
+  return t("session.expedition_road", {
+    building,
+    value: road.metricValue,
+    target: road.nextTarget,
+  });
+}


### PR DESCRIPTION
Plan item 12 of `docs/design/audits/2026-09-10.md`, the player's blocker 12.

The screen opened on distance, moving time and pace, which is what every other
running app pays in. Leagues are the one currency nothing else in this game
earns, and what they raise is the road out of the village: the word appeared
once here, as a unit on a pace figure, and the village was not mentioned at all.

"High Road · 5/15 leagues" now sits above the three numbers, in the gold this
app keeps for a reward. Same sentence the victory screen prints, off the same
query, so the two cannot come to disagree about what a walk bought. `roadLine`
moves into its own module: a component file that exports a formatter breaks
Fast Refresh, and biome says so.

Seen on a device, on a seeded outing.

**Not done, deliberately.** The audit also asks for the tile-server paragraph to
move behind the "Show the map" button. That paragraph is a privacy disclosure
about contacting a third party, and moving it after the tap turns a notice into
a confirmation. That is a product decision rather than a layout one.

140 suites, 1598 tests, `tsc`, `biome --error-on-warnings` and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP