### PR TITLE
The set screen is dark, and nothing but Done is under the thumb

### DIFF
--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -10,11 +10,8 @@ import { Crosshair, Pause } from "@/components/icons";
 import { ExercisePickerSheet } from "@/components/quests/ExercisePickerSheet";
 import { getExerciseAsset, getExerciseThumb } from "@/constants/assetMap";
 import { bossDisplayName } from "@/constants/bosses";
-import {
-  getExerciseBgForSessionStep,
-  getExerciseBgRawForSessionStep,
-} from "@/constants/exerciseColors";
 import { rankSwapCandidates, type SwapReason } from "@/constants/exerciseFilters";
+import { rawColors } from "@/constants/rawColors";
 import { critChance } from "@/db/bossFights";
 import { type Exercise, listExercises, pickableExercises } from "@/db/exercises";
 import { isOutdoors, isOutingSession } from "@/db/expeditions";
@@ -200,18 +197,21 @@ export function ActiveExerciseView() {
   const phaseLook = bossFight
     ? getPhaseLook(getPhaseFromHp(getHpPercent(bossFight.currentHp, bossFight.totalHp)))
     : null;
-  const screenBg =
-    phaseLook?.bgToken ??
-    getExerciseBgForSessionStep({
-      exercise: currentEx.exercise,
-      targetType: currentEx.target.type,
-    });
-  const screenBgRaw =
-    phaseLook?.bgRaw ??
-    getExerciseBgRawForSessionStep({
-      exercise: currentEx.exercise,
-      targetType: currentEx.target.type,
-    });
+  /**
+   * The room is dark, whatever the muscle.
+   *
+   * The screen used to take the exercise's own pastel as its ground, so a leg day painted the
+   * lower half of the session khaki and an arm day pink. On a card that is a tint; across a whole
+   * screen, in a dark-mode-only game whose anti-references rule out "flat white dashboards", it
+   * is the one place the app stops looking like itself, and the audit's player said so of the
+   * screen he spends ninety percent of his time on.
+   *
+   * The boss keeps its phase colour: a room that reddens as the monster enrages is the register
+   * this game *does* want, and it is the arena's own doing rather than a property of the muscle
+   * being trained.
+   */
+  const screenBg = phaseLook?.bgToken ?? "$bgDark";
+  const screenBgRaw = phaseLook?.bgRaw ?? rawColors.bgDark;
 
   // The hero is the elastic part of the column: the counter and the CTA take their own height
   // and the picture gets everything left over, so nothing below it is ever clipped and a tall
@@ -461,28 +461,78 @@ export function ActiveExerciseView() {
                   is already on screen but cropped into a hero, and an accordion could not show
                   it. Tapping the art itself does the same thing; this row is what makes that
                   discoverable. */}
-              {instruction?.description ? (
-                <Pressable
-                  testID="session-how-to"
-                  onPress={handleShowHowTo}
-                  hitSlop={12}
-                  accessibilityRole="button"
-                  accessibilityLabel={t("session.how_to_do_it")}
-                >
-                  <XStack
-                    items="center"
-                    justify="center"
-                    gap="$2"
-                    py="$2"
-                    opacity={0.7}
-                    hoverStyle={{ opacity: 1 }}
+              {/* Three links about the movement, on one row under its name.
+                  "Replace" and "I couldn't do this one" used to sit one line above the
+                  full-width Done button, in the landing zone of the thumb that hammers Done
+                  between two sets: a mis-tap there swapped the exercise or wrote a failure. They
+                  belong with "How to do it", which is the other thing a hero asks about the
+                  movement rather than about the set, and the counter now stands between all
+                  three and the button. */}
+              <XStack items="center" justify="center" gap="$3" opacity={0.7} flexWrap="wrap">
+                {instruction?.description ? (
+                  <Pressable
+                    testID="session-how-to"
+                    onPress={handleShowHowTo}
+                    hitSlop={12}
+                    accessibilityRole="button"
+                    accessibilityLabel={t("session.how_to_do_it")}
                   >
-                    <Text fontSize={12} fontWeight="700" color="$textSecondary">
+                    <Text py="$2" fontSize={12} fontWeight="700" color="$textSecondary">
                       {t("session.how_to_do_it")}
                     </Text>
-                  </XStack>
-                </Pressable>
-              ) : null}
+                  </Pressable>
+                ) : null}
+
+                {/* Not on an outing: a walk has no movement to swap and no set to fail. */}
+                {isOuting ? null : (
+                  <>
+                    <Text fontSize={12} color="$textSecondary" opacity={0.5}>
+                      ·
+                    </Text>
+                    <Pressable
+                      testID="session-swap-exercise"
+                      hitSlop={12}
+                      onPress={() => {
+                        selection();
+                        setSwapOpen(true);
+                      }}
+                      accessibilityRole="button"
+                      accessibilityLabel={t("quests.swap_exercise")}
+                    >
+                      <Text
+                        py="$2"
+                        fontSize={12}
+                        fontWeight="700"
+                        color="$textSecondary"
+                        numberOfLines={1}
+                      >
+                        {t("session.swap_short", "Replace")}
+                      </Text>
+                    </Pressable>
+
+                    <Text fontSize={12} color="$textSecondary" opacity={0.5}>
+                      ·
+                    </Text>
+                    <Pressable
+                      testID="session-skip-exercise"
+                      hitSlop={12}
+                      onPress={handleSkip}
+                      accessibilityRole="button"
+                      accessibilityLabel={t("session.skip_exercise")}
+                    >
+                      <Text
+                        py="$2"
+                        fontSize={12}
+                        fontWeight="700"
+                        color="$textSecondary"
+                        numberOfLines={1}
+                      >
+                        {t("session.skip_exercise")}
+                      </Text>
+                    </Pressable>
+                  </>
+                )}
+              </XStack>
             </YStack>
 
             {/* Big Counter — the loudest thing on the screen. The numerals set their own
@@ -708,72 +758,6 @@ export function ActiveExerciseView() {
             ) : null}
           </YStack>
         </YStack>
-
-        {/* One decision at two intensities — "I cannot do this set as prescribed" — so one row.
-          Out of reach is not always "I cannot": often it is "not this variation", and the sheet
-          the quest screen has always had is reachable at the moment it is actually needed. The
-          other is the honest way past a movement, deliberately quiet next to the primary action;
-          it is a release valve, not a choice being offered. Before it existed, `CHECK
-          (resultValue > 0)` made "1" the only way through, and that 1 went on to feed muscle
-          volume, the weak-area read and every target generated from them (issue #33).
-
-          Stacked, they were two full-width rows and ~100dp of link between the counter and the
-          button that ends the set — the two things that have to read as one gesture. Side by
-          side they are half that, and they finally look like what they are: siblings. The swap
-          gets its short label here; the sheet it opens still carries the full sentence.
-
-          Neither offer means anything on a slot the hero is outside for: there is no other
-          movement to walk with, and a walk that did not happen is a walk the hero simply does not
-          start. The row is not rendered at all rather than emptied, so the column closes over it
-          instead of keeping a hole where two words used to be. */}
-        {isOuting ? null : (
-          <XStack items="center" justify="center" gap="$3" opacity={0.7}>
-            <Pressable
-              testID="session-swap-exercise"
-              hitSlop={12}
-              onPress={() => {
-                selection();
-                setSwapOpen(true);
-              }}
-              accessibilityRole="button"
-              accessibilityLabel={t("quests.swap_exercise")}
-            >
-              <Text
-                py="$2"
-                fontSize={13}
-                fontWeight="700"
-                color="$textSecondary"
-                fontFamily="$body"
-                numberOfLines={1}
-              >
-                {t("session.swap_short", "Replace")}
-              </Text>
-            </Pressable>
-
-            <Text fontSize={13} color="$textSecondary" opacity={0.5}>
-              ·
-            </Text>
-
-            <Pressable
-              testID="session-skip-exercise"
-              hitSlop={12}
-              onPress={handleSkip}
-              accessibilityRole="button"
-              accessibilityLabel={t("session.skip_exercise")}
-            >
-              <Text
-                py="$2"
-                fontSize={13}
-                fontWeight="700"
-                color="$textSecondary"
-                fontFamily="$body"
-                numberOfLines={1}
-              >
-                {t("session.skip_exercise")}
-              </Text>
-            </Pressable>
-          </XStack>
-        )}
 
         {/* Footer Action */}
         {isOuting ? (

--- a/components/session/CountdownView.tsx
+++ b/components/session/CountdownView.tsx
@@ -5,10 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Text, XStack, YStack } from "tamagui";
 import { Pause } from "@/components/icons";
 import { getBossAsset, getExerciseAsset, getQuestAsset } from "@/constants/assetMap";
-import {
-  getExerciseBgForSessionStep,
-  getExerciseBgRawForSessionStep,
-} from "@/constants/exerciseColors";
+import { rawColors } from "@/constants/rawColors";
 import { formatTarget } from "@/db/targets";
 import { useCountdownCues } from "@/hooks/useCountdownCues";
 import { useHaptics } from "@/hooks/useHaptics";
@@ -95,9 +92,11 @@ export function CountdownView() {
   const phaseLook = bossFight
     ? getPhaseLook(getPhaseFromHp(getHpPercent(bossFight.currentHp, bossFight.totalHp)))
     : null;
-  const firstStep = { exercise: first.exercise, targetType: first.target.type };
-  const screenBg = phaseLook?.bgToken ?? getExerciseBgForSessionStep(firstStep);
-  const screenBgRaw = phaseLook?.bgRaw ?? getExerciseBgRawForSessionStep(firstStep);
+  const _firstStep = { exercise: first.exercise, targetType: first.target.type };
+  // The same dark ground the set screen it counts into uses. A countdown in the muscle's pastel
+  // and a session in the dark would change the room's colour the moment the number hits zero.
+  const screenBg = phaseLook?.bgToken ?? "$bgDark";
+  const screenBgRaw = phaseLook?.bgRaw ?? rawColors.bgDark;
 
   // What the hero is setting out against: the monster, else the quest's own cover. A quest a hero
   // wrote may have no cover, and then the first movement is the picture.

--- a/components/session/ExerciseInstructions.tsx
+++ b/components/session/ExerciseInstructions.tsx
@@ -78,7 +78,13 @@ export function ExerciseInstructionsModal({
       animationType={reducedMotion ? "none" : "fade"}
       onRequestClose={onClose}
     >
-      <YStack flex={1} bg="$bgOverlay" justify="center" items="center" p="$4">
+      {/* Opaque, not a scrim.
+          The paused screen renders underneath this one, and the comment that put it there said
+          two stacked `$bgOverlay` left it "under a percent of a percent". They do not: the audit's
+          screenshot reads "Game Paused", "Restart Round" and "Quit Quest" straight through the
+          card. A hero who asked what a dead bug is should not be one stray tap from ending their
+          session. Reading is its own moment, so it gets its own ground. */}
+      <YStack flex={1} bg="$bgDark" justify="center" items="center" p="$4">
         <Card testID="session-instructions" width="100%" maxW={420} bg="$surface" gap="$3">
           <ExerciseInstructionsBody instruction={instruction} artSize={220} />
           <Button

--- a/docs/design/audits/2026-09-10.md
+++ b/docs/design/audits/2026-09-10.md
@@ -165,6 +165,16 @@ costs. Both are recorded because the fix changed as a result.
   around it: the unit "Seconds" under the number, and "Keep going! Timer continues after target"
   under that, a sentence about overtime shown before the target is reached. The finding stands,
   the fix is a caption rather than a new readout.
+- **The second progress bar is the hold.** The friction list says neither of the session
+  screen's two bars tracks the set in progress. The thin one at the top is the quest's, and the
+  thicker one under the movement's name is `useSessionTimer`'s own `progress`: at 0:24 left of 30
+  it sits at a fifth, and in the boss shot at over half because 0:12 was the *elapsed* reading of
+  a longer hold. What was true is that neither was labelled, which the caption under the numeral
+  now answers.
+- **Reading the movement pauses the clock on purpose.** "Costs a pause" is the trade the code
+  made deliberately, with the reason written beside it: a hero who does not know what a dead bug
+  is should not be charged seconds for asking. What was true is the rest of that finding, that
+  the paused screen's "Quit Quest" was legible through the modal's scrim.
 - **The cameo layer is not `pointerEvents="none"` where it draws.** The comment in `screenCues.ts`
   says the layer never intercepts, and the container is `box-none`, but the figure and the bubble
   are `Pressable` on purpose, so a villager you can see can be sent away. The persona wrote "I


### PR DESCRIPTION
Three findings from the friction list of `docs/design/audits/2026-09-10.md`, all
on the screen a hero spends most of their time on.

**The room is dark, whatever the muscle.** The session took the exercise's own
pastel as its ground, so a leg day painted the lower half khaki and an arm day
pink. On a card that is a tint; across a whole screen, in a dark-mode-only game
whose anti-references rule out flat dashboards, it is the one place the app
stopped looking like itself. The countdown that leads into it changes with it,
or the room would change colour the moment the number hits zero. The boss keeps
its phase palette: a room that reddens as the monster enrages is the register
this game does want.

**"Replace" and "I couldn't do this one" are out of the landing zone.** They sat
one line above the full-width Done button, where the thumb arrives at speed
between two sets, so a mis-tap swapped the exercise or wrote a failure. They now
share a row with "How to do it" under the movement's name: all three are
questions about the movement rather than about the set, and the whole counter
stands between them and the button.

**Reading is its own moment.** The instructions modal drew over the paused screen
on a 0.92 scrim, and the comment that put it there said the layer beneath was
left "under a percent of a percent". It is not: the audit's screenshot reads
"Game Paused", "Restart Round" and "Quit Quest" straight through the card. A hero
who asked what a dead bug is was one stray tap from ending their session.

All three seen on a device.

**Two entries on that list did not survive being checked**, and § 4b of the audit
now says so: the second progress bar *is* the hold in progress, and pausing the
clock while reading is a deliberate trade with its reason written beside it. The
fourth session entry, the exercise plates leaving dark fantasy, is illustration
work rather than code.

140 suites, 1600 tests, `tsc`, `biome --error-on-warnings` and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP