### PR TITLE
Two things the device showed

### DIFF
--- a/__tests__/village-scene.test.tsx
+++ b/__tests__/village-scene.test.tsx
@@ -115,7 +115,7 @@ describe("VillageScene", () => {
     // rate that is not one-to-one named on the same line: "work units" was a currency the hero
     // met here and nowhere else.
     expect(
-      await findByText("350 reps of chest training A hold counts one rep every 3 seconds."),
+      await findByText("350 reps of chest training. A hold counts one rep every 3 seconds."),
     ).toBeTruthy();
     expect(await findByText("250 more for level 4")).toBeTruthy();
   });

--- a/components/journal/JournalStats.tsx
+++ b/components/journal/JournalStats.tsx
@@ -76,50 +76,40 @@ function StatCard({
 }
 
 /**
- * The second figure on the flame card: the bar it is judged against.
+ * The second figure on the flame card: the bar the flame is judged against.
  *
- * It used to read "Best 1092" beside a current streak of 1092, so the only comparison on the card
- * was a number against itself, and it never stated the quota that keeps the thing alive. Sessions
- * in the last seven days against the hero's own promise is the figure they can act on today.
- * "Best" comes back when it is not simply today's number, and a cache written before the window
- * existed says nothing rather than a zero, which would read as "you have trained nothing".
+ * It used to read "Best 1092" beside a current streak of 1092, so the only comparison on the
+ * card was a number against itself, and it never stated the quota that keeps the thing alive.
+ * Sessions in the last seven days against the hero's own promise is the figure they can act on
+ * today. "Best" keeps a line under it only while it is not simply today's number, which is to
+ * say while the flame is behind where it has been.
  *
  * Its own component so the card's own function keeps one branch instead of three.
  */
 function FlameSecond({ streak }: { streak: StreakInfo }) {
   const { t } = useTranslation();
 
-  if (streak.inWindow !== null && streak.quota !== null) {
-    return (
-      <YStack items="center">
-        <Text fontSize={12} color="$textSecondary">
-          {t("journal.streak_week", "This week")}
-        </Text>
-        <Text
-          fontWeight="700"
-          fontSize={20}
-          color={streak.inWindow >= streak.quota ? "$success" : "$secondary"}
-        >
-          {t("journal.streak_quota", {
-            done: streak.inWindow,
-            quota: streak.quota,
-            defaultValue: `${streak.inWindow} / ${streak.quota}`,
-          })}
-        </Text>
-      </YStack>
-    );
-  }
-
-  if (streak.best <= streak.current) return <YStack items="center" />;
-
   return (
     <YStack items="center">
       <Text fontSize={12} color="$textSecondary">
-        {t("journal.best_streak", "Best")}
+        {t("journal.streak_week", "This week")}
       </Text>
-      <Text fontWeight="700" fontSize={20} color="$secondary">
-        {streak.best}
+      <Text
+        fontWeight="700"
+        fontSize={20}
+        color={streak.inWindow >= streak.quota ? "$success" : "$secondary"}
+      >
+        {t("journal.streak_quota", {
+          done: streak.inWindow,
+          quota: streak.quota,
+          defaultValue: `${streak.inWindow} / ${streak.quota}`,
+        })}
       </Text>
+      {streak.best > streak.current ? (
+        <Text fontSize={12} color="$textSecondary">
+          {t("journal.best_streak", "Best")} {streak.best}
+        </Text>
+      ) : null}
     </YStack>
   );
 }

--- a/components/village/VillageDetailSheet.tsx
+++ b/components/village/VillageDetailSheet.tsx
@@ -207,6 +207,9 @@ function BuildingDetail({
   const prereqCode = buildingDefinitions[building.code].prerequisiteBuilding;
   const prereqName = prereqCode ? BUILDING_LABELS[prereqCode][fr ? "fr" : "en"] : "";
 
+  // The unit note is a second sentence, so the join carries the full stop. The driver strings
+  // themselves stay clause-shaped: the leagues one is reused on the victory screen after a
+  // middot, where a period would be wrong.
   const repUnitNote = t("village.rep_unit", { seconds: SECONDS_PER_REP_EQUIVALENT });
 
   // One sentence naming the deed that raises this building, in its own unit.
@@ -225,11 +228,11 @@ function BuildingDetail({
           : `${t("village.detail_muscle_driver", {
               volume: building.metricValue,
               muscle: muscleLabel,
-            })} ${repUnitNote}`;
+            })}. ${repUnitNote}`;
       case "style":
         return building.level === 0
           ? t("village.detail_unlock_style", { style: styleLabel })
-          : `${t("village.detail_style_driver", { volume: building.metricValue, style: styleLabel })} ${repUnitNote}`;
+          : `${t("village.detail_style_driver", { volume: building.metricValue, style: styleLabel })}. ${repUnitNote}`;
       case "prereq":
         return building.level === 0
           ? t("village.detail_prereq_locked", {
@@ -249,7 +252,7 @@ function BuildingDetail({
         // The one place the unit gets named. A league is the only measure Bati invents, and until
         // this line it arrived unexplained: "2,50 km" on the victory screen and "2 leagues" under
         // it, with nothing in between, and a hero in miles never told what either was worth.
-        return `${t("village.detail_leagues_driver", { count: building.metricValue })} ${t("village.league_unit")}`;
+        return `${t("village.detail_leagues_driver", { count: building.metricValue })}. ${t("village.league_unit")}`;
       default:
         return t("village.detail_bosses_driver", { count: building.metricValue });
     }

--- a/db/streaks.ts
+++ b/db/streaks.ts
@@ -46,11 +46,10 @@ export type StreakInfo = {
    *
    * The number that decides whether the flame is lit tomorrow, which the journal's card could
    * not say: it printed "1092, best 1092", a number compared to itself, and never the bar. Both
-   * are already in hand wherever the streak is computed, and `null` only on a cache written
-   * before this existed, where the card falls back to saying nothing.
+   * are already in hand wherever the streak is computed.
    */
-  inWindow: number | null;
-  quota: number | null;
+  inWindow: number;
+  quota: number;
 };
 
 export type FlameLevel = 0 | 1 | 2 | 3 | 4 | 5;
@@ -183,7 +182,15 @@ export async function getCachedStreak(): Promise<StreakInfo | null> {
     cache[row.key] = row.value;
   }
 
-  if (!cache[STREAK_CURRENT_KEY] || !cache[STREAK_BEST_KEY] || !cache[STREAK_CACHED_ON_KEY]) {
+  if (
+    !cache[STREAK_CURRENT_KEY] ||
+    !cache[STREAK_BEST_KEY] ||
+    !cache[STREAK_CACHED_ON_KEY] ||
+    // A cache written before the window key existed is a miss, not a partial hit. Serving it
+    // with a missing figure meant the card stayed silent about the week until the hero logged
+    // a session, which on a device with a same-day cache is the one thing they have not done.
+    cache[STREAK_WINDOW_KEY] === undefined
+  ) {
     return null;
   }
   if (cache[STREAK_CACHED_ON_KEY] !== dayKey(new Date())) return null;
@@ -191,17 +198,14 @@ export async function getCachedStreak(): Promise<StreakInfo | null> {
 
   const current = Number.parseInt(cache[STREAK_CURRENT_KEY], 10) || 0;
 
-  const window = cache[STREAK_WINDOW_KEY];
-
   return {
     current,
     best: Number.parseInt(cache[STREAK_BEST_KEY], 10) || 0,
     isActive: current > 0,
     lastWorkoutDate: cache[STREAK_LAST_DATE_KEY] || null,
-    // Absent on a cache written before the key existed: the card says nothing rather than a
-    // zero, which would read as "you have trained nothing this week".
-    inWindow: window === undefined ? null : Number.parseInt(window, 10),
-    quota: Number.parseInt(cache[STREAK_QUOTA_KEY] ?? "", 10) || null,
+    inWindow: Number.parseInt(cache[STREAK_WINDOW_KEY], 10) || 0,
+    // Guarded above: the cache is a miss unless this matches the quota in force right now.
+    quota: Number.parseInt(cache[STREAK_QUOTA_KEY] ?? "", 10) || 0,
   };
 }
 


### PR DESCRIPTION
Follow-up to #87, both found by looking at the phone rather than by a test.

**The flame card was blank on the right.** `getCachedStreak` served a same-day cache written before the window key existed, with `inWindow: null`, and the card's fallback was to say nothing. So the week's figure would not have appeared until the hero logged a session, which on a same-day cache is the one thing they had not done. An old cache is now a miss rather than a partial hit, which removes the nullable branch from `StreakInfo` altogether. "Best" keeps a line under the week's figure only while it is not simply today's number.

**The village sheet ran two sentences together**: "9214 reps of chest training A hold counts one rep every 3 seconds." The full stop belongs to the join, not to the strings: the leagues clause it copies is reused on the victory screen after a middot, where a period would be wrong, and `victory-expedition.test.tsx` caught exactly that when the period went into the string.

**Verified on a Fairphone 6**, dev build over Metro: the header's `361 / 2000 XP`, the history rows' `+31 XP` beside the difficulty, the flame card's `This week 11 / 2`, every ready-made oath carrying its standing with the passed ones climbed (`A 1110-day flame`, `600 sessions logged`, `4000 × Push-ups in total`), and the Forge sheet in reps. The recap's league line is a string change on an unchanged render path, covered by `expedition-recap.test.tsx`, and was not reached on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmhXfRU9u2sGUxzBbDJbrP