### PR TITLE
Maestro walks Home's Start into the session it opens

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -94,7 +94,7 @@ breaks the day someone runs the emulator in French — a `testID` never does.
 | Example | Where |
 |---------|-------|
 | `onboarding-hero-continue` | onboarding hero-setup screen |
-| `home-start-session` | home screen CTA |
+| `home-start-session` | home screen CTA, opens the offered session directly |
 | `session-complete-exercise` | active exercise footer |
 | `session-victory-continue` | victory screen |
 | `tab-adventures` | bottom tab bar |

--- a/.maestro/journal-after-session.yaml
+++ b/.maestro/journal-after-session.yaml
@@ -18,18 +18,17 @@ appId: com.guiforge.bati.dev
 
 # --- Earn something worth logging -------------------------------------------
 
+# Home's Start opens the offered session directly; `quest-start` only shows when the quest
+# reads the position and Start went to its screen instead.
 - assertVisible:
     id: "home-start-session"
 - tapOn:
     id: "home-start-session"
-
-- assertVisible:
-    id: "quests-quest-card"
 - tapOn:
-    id: "quests-quest-card"
-    index: 0
+    id: "quest-start"
+    optional: true
 
-- runFlow: subflows/complete-a-session.yaml
+- runFlow: subflows/run-a-session.yaml
 
 # --- History ----------------------------------------------------------------
 

--- a/.maestro/main-journey.yaml
+++ b/.maestro/main-journey.yaml
@@ -18,25 +18,23 @@ appId: com.guiforge.bati.dev
 
 - runFlow: subflows/complete-onboarding.yaml
 
-# --- Home -------------------------------------------------------------------
+# --- Home -> session --------------------------------------------------------
 
 - assertVisible:
     id: "home-start-session"
 
-# With no training history the smart action falls through to the quest gallery
-# (useSmartAction step 3). Deterministic on a cleared state.
+# Home's one tap: on a cleared state the stage offers a workout (a lagging muscle, or the
+# onboarding's own first session) and Start opens its session directly.
 - tapOn:
     id: "home-start-session"
 
-# --- Quest -> session -------------------------------------------------------
-
-- assertVisible:
-    id: "quests-quest-card"
+# Unless the offered quest reads the position: then Start only opens the quest screen, where
+# the location notice is, and the session starts from there.
 - tapOn:
-    id: "quests-quest-card"
-    index: 0
+    id: "quest-start"
+    optional: true
 
-- runFlow: subflows/complete-a-session.yaml
+- runFlow: subflows/run-a-session.yaml
 
 # --- Full circle ------------------------------------------------------------
 

--- a/.maestro/subflows/complete-a-session.yaml
+++ b/.maestro/subflows/complete-a-session.yaml
@@ -1,9 +1,8 @@
 # Reusable: from a quest details screen (quest-start visible) all the way through the
 # session to the victory screen, then dismiss it.
 #
-# Quests vary in rounds and exercises, so the session is walked generically rather than
-# step-counted: complete an exercise, skip the rest that follows, until victory shows up.
-# Selects by testID only, so it is locale-agnostic (en/fr).
+# The session itself is `run-a-session.yaml`, shared with Home's Start, which opens a session
+# without this screen in between. Selects by testID only, so it is locale-agnostic (en/fr).
 appId: com.guiforge.bati.dev
 ---
 - assertVisible:
@@ -11,66 +10,4 @@ appId: com.guiforge.bati.dev
 - tapOn:
     id: "quest-start"
 
-# An adventure step opens with its story before the session does. Nothing on the quest gallery
-# path shows one, so `optional` covers both entry points — but a flow that does not know about
-# the modal simply sits behind it until it times out, which is what adventure-journey did.
-- tapOn:
-    id: "narrative-confirm"
-    optional: true
-
-# Warm-up runs first and is on by default (preferences.getWarmupEnabled defaults to true).
-# Skip it: these flows are about the workout, and walking the warm-up adds minutes of real
-# timers to every run.
-#
-# Wait for the button before tapping it. A bare `optional` tap silently does nothing when the
-# warm-up screen has not mounted yet, and the flow then sat through the whole warm-up — which
-# is 4 to 10 steps depending on the quest's length, far past the 15s below. That is what made
-# adventure-journey fail and what made the passing flows take five minutes each.
-- extendedWaitUntil:
-    visible:
-      id: "session-skip-warmup"
-    timeout: 15000
-    optional: true
-- tapOn:
-    id: "session-skip-warmup"
-    optional: true
-
-# The start screen waits ten seconds, or for GO when Settings says so. Tapped either way, so a
-# flow neither sits through the wait nor hangs on it.
-- extendedWaitUntil:
-    visible:
-      id: "session-start-go"
-    timeout: 15000
-    optional: true
-- tapOn:
-    id: "session-start-go"
-    optional: true
-
-# The start screen hands over to the first exercise.
-- extendedWaitUntil:
-    visible:
-      id: "session-complete-exercise"
-    timeout: 15000
-
-# `times` is a guard against an infinite loop if a screen ever gets stuck.
-- repeat:
-    times: 40
-    while:
-      notVisible:
-        id: "session-victory-continue"
-    commands:
-      - tapOn:
-          id: "session-complete-exercise"
-          optional: true
-      - tapOn:
-          id: "session-skip-rest"
-          optional: true
-
-# Generous, because the session save writes before the button becomes usable — a slow
-# write must not fail the run.
-- extendedWaitUntil:
-    visible:
-      id: "session-victory-continue"
-    timeout: 20000
-- tapOn:
-    id: "session-victory-continue"
+- runFlow: run-a-session.yaml

--- a/.maestro/subflows/run-a-session.yaml
+++ b/.maestro/subflows/run-a-session.yaml
@@ -1,0 +1,71 @@
+# Reusable: from the moment a session opens, through it to the victory screen, then dismiss it.
+#
+# Two doors reach it: the quest details screen (`complete-a-session.yaml` taps its start first)
+# and Home's Start, which opens the session directly. Quests vary in rounds and exercises, so the
+# session is walked generically rather than step-counted: complete an exercise, skip the rest that
+# follows, until victory shows up. Selects by testID only, so it is locale-agnostic (en/fr).
+appId: com.guiforge.bati.dev
+---
+# An adventure step opens with its story before the session does. Nothing on the quest gallery
+# path shows one, so `optional` covers both entry points — but a flow that does not know about
+# the modal simply sits behind it until it times out, which is what adventure-journey did.
+- tapOn:
+    id: "narrative-confirm"
+    optional: true
+
+# Warm-up runs first and is on by default (preferences.getWarmupEnabled defaults to true).
+# Skip it: these flows are about the workout, and walking the warm-up adds minutes of real
+# timers to every run.
+#
+# Wait for the button before tapping it. A bare `optional` tap silently does nothing when the
+# warm-up screen has not mounted yet, and the flow then sat through the whole warm-up — which
+# is 4 to 10 steps depending on the quest's length, far past the 15s below. That is what made
+# adventure-journey fail and what made the passing flows take five minutes each.
+- extendedWaitUntil:
+    visible:
+      id: "session-skip-warmup"
+    timeout: 15000
+    optional: true
+- tapOn:
+    id: "session-skip-warmup"
+    optional: true
+
+# The start screen waits ten seconds, or for GO when Settings says so. Tapped either way, so a
+# flow neither sits through the wait nor hangs on it.
+- extendedWaitUntil:
+    visible:
+      id: "session-start-go"
+    timeout: 15000
+    optional: true
+- tapOn:
+    id: "session-start-go"
+    optional: true
+
+# The start screen hands over to the first exercise.
+- extendedWaitUntil:
+    visible:
+      id: "session-complete-exercise"
+    timeout: 15000
+
+# `times` is a guard against an infinite loop if a screen ever gets stuck.
+- repeat:
+    times: 40
+    while:
+      notVisible:
+        id: "session-victory-continue"
+    commands:
+      - tapOn:
+          id: "session-complete-exercise"
+          optional: true
+      - tapOn:
+          id: "session-skip-rest"
+          optional: true
+
+# Generous, because the session save writes before the button becomes usable — a slow
+# write must not fail the run.
+- extendedWaitUntil:
+    visible:
+      id: "session-victory-continue"
+    timeout: 20000
+- tapOn:
+    id: "session-victory-continue"


### PR DESCRIPTION
Follow-up to #90: Home's Start now opens the session directly, so `main-journey` and `journal-after-session` no longer wait for the quest gallery after tapping it.

- New `subflows/run-a-session.yaml`: the session walk, shared by Home's Start and the quest screen.
- `complete-a-session.yaml` taps `quest-start`, then runs it.
- Both flows tap Start, then `quest-start` optionally (a quest that reads the position still opens its screen).

Not run on a device yet: the phone was unplugged. YAML parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgrCpCCyPjTak7oZvWkjVc
