### PR TITLE
The outing shows its map, and the finish button says to hold

### DIFF
--- a/__mocks__/@maplibre/maplibre-react-native.tsx
+++ b/__mocks__/@maplibre/maplibre-react-native.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { View } from "react-native";
+
+/**
+ * MapLibre, for every suite that mounts a screen with a map on it.
+ *
+ * The renderer is native and jest has none: the commonjs build calls
+ * `TurboModuleRegistry.getEnforcing` the moment it is imported, so a screen that merely contains a
+ * map fails to load. Jest picks this file up by itself for anything under `node_modules`. A suite
+ * that needs to read what the map was handed mocks the package itself, as
+ * `__tests__/expedition-recap.test.tsx` and `__tests__/live-map.test.tsx` do, and its factory wins.
+ */
+const passthrough =
+  (testID: string) =>
+  ({ children }: { children?: ReactNode }) => <View testID={testID}>{children}</View>;
+
+// `Map` shadows the global of the same name, which is the one thing a file edited later should
+// not be surprised by; the export keeps the package's own name.
+const MapView = passthrough("maplibre");
+
+export { MapView as Map };
+export const Camera = passthrough("maplibre-camera");
+export const GeoJSONSource = passthrough("maplibre-source");
+export const Layer = passthrough("maplibre-layer");

--- a/__tests__/expedition-recap.test.tsx
+++ b/__tests__/expedition-recap.test.tsx
@@ -352,7 +352,7 @@ describe("a session that left the walls", () => {
 
   test("credits OpenStreetMap and the tile host, which MapLibre's own widget is not doing", async () => {
     await mount();
-    const line = await screen.findByTestId("recap-attribution");
+    const line = await screen.findByTestId("map-attribution");
     expect(line).toHaveTextContent(/OpenStreetMap contributors/);
     expect(line).toHaveTextContent(/OpenMapTiles/);
     expect(line).toHaveTextContent(/OpenFreeMap/);
@@ -531,17 +531,17 @@ describe("a hero who has not allowed the basemap", () => {
   test("offers the map, naming the host, and one tap is the whole answer", async () => {
     await mount();
 
-    const offer = await screen.findByTestId("recap-map-offer");
+    const offer = await screen.findByTestId("map-offer");
     expect(offer).toHaveTextContent(/tiles\.openfreemap\.org/);
-    expect(screen.queryByTestId("recap-attribution")).toBeNull();
+    expect(screen.queryByTestId("map-attribution")).toBeNull();
 
     await act(async () => {
-      await fireEvent.press(screen.getByTestId("recap-map-enable"));
+      await fireEvent.press(screen.getByTestId("map-enable"));
     });
 
     expect(useSettingsStore.getState().mapTilesEnabled).toBe(true);
-    expect(screen.queryByTestId("recap-map-offer")).toBeNull();
-    expect(screen.getByTestId("recap-attribution")).toBeTruthy();
+    expect(screen.queryByTestId("map-offer")).toBeNull();
+    expect(screen.getByTestId("map-attribution")).toBeTruthy();
     expect(JSON.stringify(mockMapStyle.mock.calls.at(-1)?.[0])).toContain("openfreemap");
   });
 
@@ -556,6 +556,6 @@ describe("a hero who has not allowed the basemap", () => {
     await mount();
 
     expect(await screen.findByTestId("recap-no-trace")).toBeTruthy();
-    expect(screen.queryByTestId("recap-map-offer")).toBeNull();
+    expect(screen.queryByTestId("map-offer")).toBeNull();
   });
 });

--- a/__tests__/gps-trace.test.ts
+++ b/__tests__/gps-trace.test.ts
@@ -151,6 +151,25 @@ describe("toTrace", () => {
     expect(broken.path.geometry.coordinates).toHaveLength(2);
   });
 
+  // MapLibre refuses a line of one point, in a red box: "A line string must have two or more
+  // coordinate points". The first fix of every live walk is exactly that, and the recap met it too
+  // wherever a break left a single fix on its own.
+  test("the path never hands MapLibre a line of one point", () => {
+    const first = toTrace([fix({ lat: 43.6045, lon: 1.4437, distFromPrev: 0 })]);
+    expect(first.path.geometry.coordinates).toEqual([]);
+    // The hero is still somewhere: the pip reads `end`, which a lone fix does have.
+    expect(first.end).toEqual([1.4437, 43.6045]);
+
+    const stranded = toTrace([
+      fix({ lat: 43.6045, lon: 1.4437, t: 0, distFromPrev: 0 }),
+      fix({ lat: 43.6039, lon: 1.4451, t: 1000 }),
+      // A jump the reducer refuses, then nothing yet: one fix alone on the far side.
+      fix({ lat: 43.61, lon: 1.46, t: 2000, distFromPrev: RULES.teleportM + 1 }),
+    ]);
+    expect(stranded.path.geometry.coordinates).toHaveLength(1);
+    expect(stranded.path.geometry.coordinates[0]).toHaveLength(2);
+  });
+
   test("the best league's cuff is one line, and it is empty when there is no best league", () => {
     expect(toTrace(walkEast(300, 2)).bestLine.features).toEqual([]);
 

--- a/__tests__/live-map.test.tsx
+++ b/__tests__/live-map.test.tsx
@@ -1,0 +1,122 @@
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+import { TamaguiProvider } from "tamagui";
+import { LiveMap } from "@/components/session/LiveMap";
+import type { LocationFix } from "@/modules/bati-location";
+import { useExpeditionStore } from "@/stores/expedition";
+import { useSettingsStore } from "@/stores/settings";
+import config from "@/tamagui.config";
+
+/**
+ * The map a hero sees while they are out.
+ *
+ * Three things are checked, and none of them is what MapLibre draws: that nothing is framed before
+ * the sky has given a position (a camera centred nowhere is the Gulf of Guinea), that the camera
+ * follows the last fix, and that the refused state asks the network for nothing. The last one is
+ * the same assertion the recap makes, for the same promise, on the second screen that keeps it.
+ */
+
+/** Every style handed to MapLibre, in order. */
+const mockMapStyle = jest.fn<void, [unknown]>();
+/** Every centre handed to the camera, in order. */
+const mockCenter = jest.fn<void, [unknown]>();
+
+jest.mock("@/db/client", () => ({ db: {}, schema: {}, runMigrations: jest.fn() }));
+jest.mock("@/db", () => ({
+  preferences: { setMapTilesEnabled: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock("@/db/gps", () => ({ appendPoints: jest.fn(), pointsOf: jest.fn() }));
+jest.mock("@/modules/bati-location", () => ({ isAvailable: () => false }));
+jest.mock("@/stores/session", () => ({
+  recordedDurationSeconds: () => 0,
+  useSessionStore: { getState: () => ({}) },
+}));
+jest.mock("@/src/reportError", () => ({ reportError: jest.fn() }));
+jest.mock("expo-localization", () => ({
+  getLocales: () => [{ languageCode: "en", languageTag: "en-US" }],
+}));
+jest.mock("@maplibre/maplibre-react-native", () => {
+  const { View } = require("react-native");
+  const passthrough =
+    (testID: string) =>
+    ({ children }: { children?: React.ReactNode }) => <View testID={testID}>{children}</View>;
+  return {
+    Map: ({ children, mapStyle }: { children?: React.ReactNode; mapStyle?: unknown }) => {
+      mockMapStyle(mapStyle);
+      return <View testID="maplibre">{children}</View>;
+    },
+    Camera: ({ center }: { center?: unknown }) => {
+      mockCenter(center);
+      return null;
+    },
+    GeoJSONSource: passthrough("maplibre-source"),
+    Layer: passthrough("maplibre-layer"),
+  };
+});
+
+import "@/i18n";
+
+const T0 = Date.UTC(2026, 8, 11, 7, 0, 0);
+
+/** A hero walking north at 1.4 m/s, one fix a second. */
+const walking = (i: number): LocationFix => ({
+  t: T0 + i * 1000,
+  lat: 43.6 + i * 0.0000126,
+  lon: 1.44,
+  ele: 100,
+  acc: 4,
+  speed: 1.4,
+  distFromPrev: i === 0 ? 0 : 1.4,
+});
+
+async function mount(fixes: LocationFix[], tiles: boolean) {
+  useExpeditionStore.setState({ fixes });
+  useSettingsStore.setState({ language: "en", mapTilesEnabled: tiles });
+  await act(async () => {
+    await render(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <LiveMap minHeight={200} topInset={0} />
+      </TamaguiProvider>,
+    );
+  });
+}
+
+const lastStyle = () => JSON.stringify(mockMapStyle.mock.calls.at(-1)?.[0]);
+
+beforeEach(() => {
+  mockMapStyle.mockClear();
+  mockCenter.mockClear();
+});
+
+test("before the first fix it holds the place and frames nothing", async () => {
+  await mount([], true);
+
+  expect(screen.getByTestId("live-map")).toBeTruthy();
+  expect(screen.queryByTestId("maplibre")).toBeNull();
+  // No credit for tiles that were never fetched, and no offer for a map that is not there yet.
+  expect(screen.queryByTestId("map-attribution")).toBeNull();
+  expect(screen.queryByTestId("map-offer")).toBeNull();
+});
+
+test("follows the hero, and fetches nothing until the hero says yes", async () => {
+  const fixes = Array.from({ length: 10 }, (_, i) => walking(i));
+  await mount(fixes, false);
+
+  expect(screen.getByTestId("maplibre")).toBeTruthy();
+  const last = fixes.at(-1);
+  expect(mockCenter.mock.calls.at(-1)?.[0]).toEqual([last?.lon, last?.lat]);
+
+  // Matched against any URL rather than the host: a source written back by mistake is a request,
+  // whichever host it points at.
+  expect(lastStyle()).not.toMatch(/https?:\/\//);
+  expect(screen.getByTestId("map-offer")).toBeTruthy();
+  expect(screen.queryByTestId("map-attribution")).toBeNull();
+
+  await act(async () => {
+    await fireEvent.press(screen.getByTestId("map-enable"));
+  });
+
+  expect(useSettingsStore.getState().mapTilesEnabled).toBe(true);
+  expect(lastStyle()).toMatch(/tiles\.openfreemap\.org/);
+  expect(screen.queryByTestId("map-offer")).toBeNull();
+  expect(screen.getByTestId("map-attribution")).toBeTruthy();
+});

--- a/__tests__/live-map.test.tsx
+++ b/__tests__/live-map.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react-native";
-import { TamaguiProvider } from "tamagui";
+import { TamaguiProvider, Text } from "tamagui";
 import { LiveMap } from "@/components/session/LiveMap";
 import type { LocationFix } from "@/modules/bati-location";
 import { useExpeditionStore } from "@/stores/expedition";
@@ -74,7 +74,7 @@ async function mount(fixes: LocationFix[], tiles: boolean) {
   await act(async () => {
     await render(
       <TamaguiProvider config={config} defaultTheme="dark">
-        <LiveMap minHeight={200} topInset={0} />
+        <LiveMap minHeight={200} topInset={0} placeholder={<Text>the movement's picture</Text>} />
       </TamaguiProvider>,
     );
   });
@@ -87,10 +87,13 @@ beforeEach(() => {
   mockCenter.mockClear();
 });
 
-test("before the first fix it holds the place and frames nothing", async () => {
+test("before the first fix it shows what it was handed, and frames nothing", async () => {
   await mount([], true);
 
-  expect(screen.getByTestId("live-map")).toBeTruthy();
+  // The movement's picture, on the session screen. An empty dark slot while the sky is being
+  // found read as a map that failed to load.
+  expect(screen.getByText("the movement's picture")).toBeTruthy();
+  expect(screen.queryByTestId("live-map")).toBeNull();
   expect(screen.queryByTestId("maplibre")).toBeNull();
   // No credit for tiles that were never fetched, and no offer for a map that is not there yet.
   expect(screen.queryByTestId("map-attribution")).toBeNull();

--- a/__tests__/session-outing-view.test.tsx
+++ b/__tests__/session-outing-view.test.tsx
@@ -4,6 +4,7 @@ import { TamaguiProvider } from "tamagui";
 
 import { ActiveExerciseView } from "@/components/session/ActiveExerciseView";
 import type { Quest } from "@/db/quests";
+import { useExpeditionStore } from "@/stores/expedition";
 import { useSessionStore } from "@/stores/session";
 import { useSettingsStore } from "@/stores/settings";
 import config from "@/tamagui.config";
@@ -130,6 +131,7 @@ async function mountRunning(quest: Quest) {
   // Animated keeps updating an Animated(View) after the test that mounted it, and the suite spent
   // most of its wall clock waiting on transitions no assertion looks at.
   useSettingsStore.setState({ soundEnabled: true, language: "en", reducedMotion: true });
+  useExpeditionStore.setState({ fixes: [] });
   useSessionStore.setState({
     quest,
     status: "running",
@@ -197,7 +199,14 @@ describe("a walk, on the screen a hero stares at while walking", () => {
 
     // The panel is the readout, and it is there.
     expect(screen.getByText("Finding the sky")).toBeTruthy();
-    // And the map holds the place the movement's picture takes on every other set.
+    // The movement's picture holds the slot until the sky gives a position, and the map takes it
+    // over with the first fix. An empty dark slot in between read as a map that failed to load.
+    expect(screen.queryByTestId("live-map")).toBeNull();
+    await act(() => {
+      useExpeditionStore.setState({
+        fixes: [{ t: NOW, lat: 43.6, lon: 1.44, ele: 100, acc: 4, speed: 1.4, distFromPrev: 0 }],
+      });
+    });
     expect(screen.getByTestId("live-map")).toBeTruthy();
 
     // The 72px numeral, its unit label, the hint under it, and the ghost line are all gone.

--- a/__tests__/session-outing-view.test.tsx
+++ b/__tests__/session-outing-view.test.tsx
@@ -197,6 +197,8 @@ describe("a walk, on the screen a hero stares at while walking", () => {
 
     // The panel is the readout, and it is there.
     expect(screen.getByText("Finding the sky")).toBeTruthy();
+    // And the map holds the place the movement's picture takes on every other set.
+    expect(screen.getByTestId("live-map")).toBeTruthy();
 
     // The 72px numeral, its unit label, the hint under it, and the ghost line are all gone.
     expect(screen.queryByText("0:03")).toBeNull();
@@ -227,6 +229,7 @@ describe("a plain hold, which still has a duration to count", () => {
     await mountRunning(questWith(mockPlank));
 
     expect(screen.queryByText("Finding the sky")).toBeNull();
+    expect(screen.queryByTestId("live-map")).toBeNull();
     expect(screen.getByText("0:03")).toBeTruthy();
     // The caption names the target rather than the unit: the number counts down to it, and
     // "Seconds" left "0:03" as readable as an elapsed count. See docs/design/audits/2026-09-10.md.
@@ -254,9 +257,10 @@ describe("finishing an outing", () => {
   test("ends on a hold, never on a tap, with nothing to swap or skip beside it", async () => {
     await mountRunning(questWith(mockWalk));
 
-    // One verb on screen, the other reserved for the screen reader.
-    expect(screen.getByText("Finish the outing")).toBeTruthy();
-    expect(screen.queryByText("Hold to finish the outing")).toBeNull();
+    // The gesture is the label. "Finish the outing" read as a tap, and a tap is the one thing this
+    // button refuses, so heroes pressed it, felt a buzz and decided it was broken.
+    expect(screen.getByText("Hold to finish")).toBeTruthy();
+    expect(screen.queryByText("Finish the outing")).toBeNull();
 
     // Neither offer means anything outside: there is no other movement to walk with, and a walk
     // that did not happen is one the hero does not start.

--- a/__tests__/store-expedition.test.ts
+++ b/__tests__/store-expedition.test.ts
@@ -149,6 +149,9 @@ describe("stores/expedition", () => {
     expect(track.distanceM).toBeGreaterThan(0);
     expect(track.paused).toBe(false);
     expect(lastFix?.t).toBe(T0 + 19 * 1000);
+    // The live map draws from these. Every fix, the rejected ones too: the trace decides what
+    // breaks the line, the same way it does on the recap.
+    expect(store.getState().fixes).toHaveLength(20);
   });
 
   test("a distance goal buzzes once when the ground is covered, and says so in the notification", async () => {
@@ -267,11 +270,14 @@ describe("stores/expedition", () => {
     expect(track.startedAt).not.toBeNull();
     expect(track.distanceM).toBeGreaterThan(20);
     expect(lastFix?.t).toBe(T0 + 19 * 1000);
+    // The map comes back with the line already walked, not a dot where the hero resumed.
+    expect(store.getState().fixes).toEqual(walked);
 
     // And it keeps going from there rather than from zero.
     const before = store.getState().track.distanceM;
     emit({ ...walking(20), t: T0 + 20_000 });
     expect(store.getState().track.distanceM).toBeGreaterThan(before);
+    expect(store.getState().fixes).toHaveLength(21);
   });
 
   test("a resumed outing that already met its goal knows it", async () => {
@@ -312,6 +318,7 @@ describe("stores/expedition", () => {
     expect(store.getState().track.distanceM).toBe(0);
     expect(store.getState().track.startedAt).toBeNull();
     expect(store.getState().lastFix).toBeNull();
+    expect(store.getState().fixes).toEqual([]);
   });
 
   test("and neither does one refused for having no native half", async () => {

--- a/app/recap.tsx
+++ b/app/recap.tsx
@@ -13,11 +13,12 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text, XStack, YStack } from "tamagui";
-import { AppButton, AppIconButton } from "@/components/common/AppButton";
+import { AppIconButton } from "@/components/common/AppButton";
 import { Figure } from "@/components/common/Figure";
 import { Skeleton } from "@/components/common/Skeleton";
 import { useToast } from "@/components/common/Toast";
 import { ChevronLeft, Share2 } from "@/components/icons";
+import { MapFootnote } from "@/components/session/MapFootnote";
 import { roadLine } from "@/components/session/roadLine";
 import { getDateTimeFormat } from "@/constants/dateFormatters";
 import {
@@ -26,7 +27,12 @@ import {
   formatPace,
   formatSpeedAsPace,
 } from "@/constants/distanceFormat";
-import { MAP_ATTRIBUTION, mapStyle, mapStyleNoTiles } from "@/constants/mapStyle";
+import {
+  LEAGUE_PIP_PAINT,
+  mapStyle,
+  mapStyleNoTiles,
+  TRACE_GLOW_PAINT,
+} from "@/constants/mapStyle";
 import { rawColors } from "@/constants/rawColors";
 import { outingSession, pointsOf } from "@/db/gps";
 import type { DistanceUnit } from "@/db/preferences";
@@ -243,41 +249,6 @@ function Figures({
 }
 
 /**
- * The line under the map, and which of the two lines it is says what actually happened.
- *
- * Allowed, it is the credit: ODbL requires the OSM one and OpenFreeMap requires its own to be
- * displayed once MapLibre's attribution button is off, which it is here. Refused, that credit
- * would be a claim rather than a courtesy, because nothing of theirs was ever fetched, so its
- * place is taken by the offer.
- *
- * The offer's sentence is the confirmation. It names the host and says what leaves before a
- * single byte does, which is the whole of what a dialog would have asked twice; the tap is the
- * answer, and the basemap arrives under the trace that is already on screen.
- */
-function MapFootnote({ enabled, onEnable }: { enabled: boolean; onEnable: () => void }) {
-  const { t } = useTranslation();
-
-  if (enabled) {
-    return (
-      <Text testID="recap-attribution" fontSize={11} color="$muted" style={{ textAlign: "center" }}>
-        {MAP_ATTRIBUTION} {t("recap.privacy")}
-      </Text>
-    );
-  }
-
-  return (
-    <YStack testID="recap-map-offer" gap="$3">
-      <Text fontSize={12} color="$textSecondary" style={{ textAlign: "center" }}>
-        {t("recap.map_offer")}
-      </Text>
-      <AppButton testID="recap-map-enable" variant="outline" fontSize={16} onPress={onEnable}>
-        {t("recap.map_enable")}
-      </AppButton>
-    </YStack>
-  );
-}
-
-/**
  * The High Road, as it stands now.
  *
  * The same read the victory screen makes, for the same sentence: leagues are the one currency
@@ -325,7 +296,6 @@ export default function ExpeditionRecapScreen() {
   // Off unless the hero has said yes. The whole map branch below reads this, and the style it
   // picks is what decides whether this screen touches a network at all.
   const mapTilesEnabled = useSettingsStore((s) => s.mapTilesEnabled);
-  const setMapTilesEnabled = useSettingsStore((s) => s.setMapTilesEnabled);
   const { showError } = useToast();
 
   const sessionUuid = Array.isArray(params.session) ? params.session[0] : params.session;
@@ -409,17 +379,7 @@ export default function ExpeditionRecapScreen() {
 
   // Neither line belongs under a screen that never drew a map: there is no credit to give and
   // nothing to switch on.
-  const footnote =
-    trace.bounds === null ? null : (
-      <MapFootnote
-        enabled={mapTilesEnabled}
-        onEnable={() => {
-          setMapTilesEnabled(true).catch((error) => {
-            reportError("recap.mapTilesWrite", error);
-          });
-        }}
-      />
-    );
+  const footnote = trace.bounds === null ? null : <MapFootnote />;
 
   const header = (
     <XStack items="center" gap="$3" px="$5" pt={insets.top + 12} pb="$3">
@@ -530,12 +490,7 @@ export default function ExpeditionRecapScreen() {
                   id="trace-glow"
                   type="line"
                   layout={{ "line-cap": "round", "line-join": "round" }}
-                  paint={{
-                    "line-color": rawColors.resourceGold,
-                    "line-width": 14,
-                    "line-opacity": 0.18,
-                    "line-blur": 12,
-                  }}
+                  paint={TRACE_GLOW_PAINT}
                 />
               </GeoJSONSource>
 
@@ -575,17 +530,7 @@ export default function ExpeditionRecapScreen() {
               {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
               <GeoJSONSource id="trace-leagues" data={trace.leagues}>
                 {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-                <Layer
-                  id="trace-league-pips"
-                  type="circle"
-                  paint={{
-                    "circle-radius": 3,
-                    "circle-color": rawColors.bgDark,
-                    "circle-stroke-width": 2,
-                    "circle-stroke-color": rawColors.resourceGold,
-                    "circle-opacity": 0.9,
-                  }}
-                />
+                <Layer id="trace-league-pips" type="circle" paint={LEAGUE_PIP_PAINT} />
               </GeoJSONSource>
 
               {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -224,6 +224,17 @@ export function ActiveExerciseView() {
   // and the picture gets everything left over, so nothing below it is ever clipped and a tall
   // screen shows more movement rather than more empty tint. This is only its floor.
   const heroMinHeight = Math.round(sessionArtHeight(width, height) * 0.6);
+  const hero = (
+    <ExerciseHero
+      source={getExerciseAsset(currentEx.exercise.imagePath)}
+      name={exerciseName}
+      minHeight={heroMinHeight}
+      fadeTo={screenBgRaw}
+      topInset={insets.top}
+      onPress={handleShowHowTo}
+      accessibilityLabel={t("session.how_to_do_it")}
+    />
+  );
   const targetMuscle = currentEx.exercise.muscles[0];
 
   /**
@@ -305,17 +316,10 @@ export function ActiveExerciseView() {
           </XStack>
         </BossArena>
       ) : isOuting ? (
-        <LiveMap minHeight={heroMinHeight} topInset={insets.top} />
+        // The movement's picture until the sky gives a position, then the map in its place.
+        <LiveMap minHeight={heroMinHeight} topInset={insets.top} placeholder={hero} />
       ) : (
-        <ExerciseHero
-          source={getExerciseAsset(currentEx.exercise.imagePath)}
-          name={exerciseName}
-          minHeight={heroMinHeight}
-          fadeTo={screenBgRaw}
-          topInset={insets.top}
-          onPress={handleShowHowTo}
-          accessibilityLabel={t("session.how_to_do_it")}
-        />
+        hero
       )}
 
       {/* The HUD: where you are, how far in, and the way out — one row floating over the art

--- a/components/session/ActiveExerciseView.tsx
+++ b/components/session/ActiveExerciseView.tsx
@@ -32,6 +32,7 @@ import { ExerciseHero } from "./ExerciseHero";
 import { ExerciseInstructionsModal } from "./ExerciseInstructions";
 import { ExpeditionPanel } from "./ExpeditionPanel";
 import { GhostLine } from "./GhostLine";
+import { LiveMap } from "./LiveMap";
 import { sessionArtHeight } from "./sessionArt";
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Main workout session view with multiple UI states
@@ -303,6 +304,8 @@ export function ActiveExerciseView() {
             )}
           </XStack>
         </BossArena>
+      ) : isOuting ? (
+        <LiveMap minHeight={heroMinHeight} topInset={insets.top} />
       ) : (
         <ExerciseHero
           source={getExerciseAsset(currentEx.exercise.imagePath)}
@@ -821,8 +824,10 @@ const FINISH_ACTION = "finishOuting";
  * costs three props and no extra state, which the alternative - a tap plus a confirmation, gated
  * on `AccessibilityInfo.isScreenReaderEnabled()` - does not.
  *
- * One visible verb: the button says "Finish the outing", and "Hold to finish" is what the screen
- * reader says. Both on screen at once would be two labels for one control.
+ * The label is the gesture. It said "Finish the outing", which reads as a tap, and a tap is the
+ * one thing this button refuses: heroes pressed it, felt a buzz and decided it was broken. Now it
+ * says "Hold to finish", and the name TalkBack offers in its actions menu keeps the plain verb,
+ * because there the action is chosen rather than held.
  */
 function OutingFinishButton({ onFinish }: { onFinish: () => void }) {
   const { t } = useTranslation();
@@ -879,8 +884,10 @@ function OutingFinishButton({ onFinish }: { onFinish: () => void }) {
         >
           <YStack flex={1} bg="$success" />
         </Animated.View>
-        <Text color="$text" fontSize={24} fontWeight="700">
-          {label}
+        {/* 20 and not 24: "Maintiens pour terminer" is the long form, and it has to hold one
+            line on a 320dp screen. */}
+        <Text color="$text" fontSize={20} fontWeight="700" numberOfLines={1}>
+          {t("session.expedition_hold_to_finish")}
         </Text>
       </YStack>
     </Pressable>

--- a/components/session/ExerciseHero.tsx
+++ b/components/session/ExerciseHero.tsx
@@ -3,6 +3,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import type { ImageSourcePropType } from "react-native";
 import { H1, YStack } from "tamagui";
 import { rawColors } from "@/constants/rawColors";
+import { HUD_HEIGHT } from "./sessionArt";
 
 type ExerciseHeroProps = {
   source: ImageSourcePropType;
@@ -31,9 +32,6 @@ type ExerciseHeroProps = {
  * already proved that a painting carries a session screen better than a card does. The
  * difference is that this one has no card around it at all.
  */
-/** The floating HUD row in ActiveExerciseView: 8 top + ~36 row + 8 gap + 3 hairline. */
-const HUD_HEIGHT = 56;
-
 export function ExerciseHero({
   source,
   name,

--- a/components/session/ExpeditionPanel.tsx
+++ b/components/session/ExpeditionPanel.tsx
@@ -45,9 +45,10 @@ function statusKey(error: string | null, track: TrackState, goalReached: boolean
 /**
  * What a hero sees while they are out.
  *
- * Numbers and nothing else, which is a battery decision before it is a design one: the screen
- * dominates the power draw of a session far more than the GPS chip does, so the map waits for
- * the recap where it can be looked at once. See docs/designs/gps-without-google.md.
+ * Numbers, under the map `LiveMap` draws in the slot the movement's picture takes on every other
+ * set. The screen is still never held awake on an outing: it dominates the power draw of a
+ * session far more than the GPS chip does, so the map only costs while the hero is looking. See
+ * docs/designs/map-immersion.md § The live map.
  *
  * Everything here reads the live store rather than the fixes: `stores/expedition` folds each
  * fix through the reducer as it lands, and a second derivation on this screen would be a second

--- a/components/session/LiveMap.tsx
+++ b/components/session/LiveMap.tsx
@@ -1,0 +1,147 @@
+// `Map` is MapLibre's map component and shadows the global of the same name; aliased for the same
+// reason as in `app/recap.tsx`.
+import { Camera, GeoJSONSource, Layer, Map as MapLibreMap } from "@maplibre/maplibre-react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { YStack } from "tamagui";
+import { MapFootnote } from "@/components/session/MapFootnote";
+import { HUD_HEIGHT } from "@/components/session/sessionArt";
+import {
+  LEAGUE_PIP_PAINT,
+  mapStyle,
+  mapStyleNoTiles,
+  TRACE_GLOW_PAINT,
+} from "@/constants/mapStyle";
+import { rawColors } from "@/constants/rawColors";
+import { toTrace } from "@/src/gps/trace";
+import { useExpeditionStore } from "@/stores/expedition";
+import { useSettingsStore } from "@/stores/settings";
+
+/** Close enough to read the street being walked, far enough to see the next turn. */
+const FOLLOW_ZOOM = 16;
+
+/** One fix a second, so the camera glides for as long as the next one takes to arrive. */
+const FOLLOW_MS = 1000;
+
+/**
+ * The walk so far, on the map, while it is happening.
+ *
+ * It takes the place the movement's picture takes on every other set, because a walk has no form
+ * to demonstrate and the picture was a still of someone else's. Same size rules as `ExerciseHero`,
+ * so the column below it lays out the same way on both.
+ *
+ * The recap's style and the recap's gold, with less on it. No pace ramp: its ends are this run's
+ * own percentiles, which move with every fix, so the colours would shift under the hero's eyes.
+ * The camera follows the last fix and every gesture is off, since a map that can be panned is a
+ * map that gets panned by a pocket.
+ *
+ * This reverses "numbers only, battery decision" from docs/designs/gps-without-google.md. The
+ * screen is still never held awake on an outing, and MapLibre draws nothing while it is off.
+ *
+ * Nothing is framed before the first fix: a camera centred nowhere is the middle of the Gulf of
+ * Guinea, and the panel under it already says the sky is being found.
+ */
+export function LiveMap({ minHeight, topInset }: { minHeight: number; topInset: number }) {
+  const fixes = useExpeditionStore((s) => s.fixes);
+  const tilesEnabled = useSettingsStore((s) => s.mapTilesEnabled);
+
+  // ponytail: the whole trace is folded again on every fix, a few milliseconds for an hour's
+  // 3,600 points, and it runs with the screen off too because the store still notifies. Fold
+  // incrementally, or skip while the app is in the background, if a measured walk shows the cost.
+  const trace = toTrace(fixes);
+  const here = trace.end;
+
+  return (
+    <YStack
+      testID="live-map"
+      // Plain RN flex, for the reason `ExerciseHero` gives: Tamagui's `flex={1}` sizes to content.
+      style={{ flex: 1 }}
+      minH={topInset + HUD_HEIGHT + minHeight}
+      width="100%"
+      bg="$bgDark"
+    >
+      {here === null ? null : (
+        <>
+          <MapLibreMap
+            style={{ flex: 1 }}
+            mapStyle={tilesEnabled ? mapStyle : mapStyleNoTiles}
+            // The credit is `MapFootnote`, in the app's own type, as on the recap.
+            attribution={false}
+            logo={false}
+            compass={false}
+            dragPan={false}
+            touchZoom={false}
+            touchRotate={false}
+            touchPitch={false}
+            doubleTapZoom={false}
+          >
+            <Camera center={here} zoom={FOLLOW_ZOOM} duration={FOLLOW_MS} easing="linear" />
+
+            {/* biome-ignore lint/correctness/useUniqueElementIds: MapLibre source and layer ids
+                are its own style namespace, not DOM ids. */}
+            <GeoJSONSource id="live-path" data={trace.path}>
+              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+              <Layer
+                id="live-glow"
+                type="line"
+                layout={{ "line-cap": "round", "line-join": "round" }}
+                paint={TRACE_GLOW_PAINT}
+              />
+              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+              <Layer
+                id="live-line"
+                type="line"
+                layout={{ "line-cap": "round", "line-join": "round" }}
+                paint={{ "line-color": rawColors.resourceGold, "line-width": 4 }}
+              />
+            </GeoJSONSource>
+
+            {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+            <GeoJSONSource id="live-leagues" data={trace.leagues}>
+              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+              <Layer id="live-league-pips" type="circle" paint={LEAGUE_PIP_PAINT} />
+            </GeoJSONSource>
+
+            {/* Where the hero is: the recap's end pip, since that is what it will become. */}
+            {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+            <GeoJSONSource
+              id="live-here"
+              data={{
+                type: "Feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: here },
+              }}
+            >
+              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+              <Layer
+                id="live-here-pip"
+                type="circle"
+                paint={{
+                  "circle-radius": 6,
+                  "circle-color": rawColors.resourceFire,
+                  "circle-stroke-width": 2,
+                  "circle-stroke-color": rawColors.bgDark,
+                }}
+              />
+            </GeoJSONSource>
+          </MapLibreMap>
+
+          {/* The status bar's band, like the picture this replaces, and the fade into the panel. */}
+          <LinearGradient
+            colors={[rawColors.bgDark, "transparent"]}
+            style={{ position: "absolute", top: 0, left: 0, right: 0, height: topInset + 28 }}
+            pointerEvents="none"
+          />
+          <LinearGradient
+            colors={["transparent", rawColors.bgDark]}
+            style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: 56 }}
+            pointerEvents="none"
+          />
+
+          <YStack position="absolute" b="$3" l="$4" r="$4">
+            <MapFootnote />
+          </YStack>
+        </>
+      )}
+    </YStack>
+  );
+}

--- a/components/session/LiveMap.tsx
+++ b/components/session/LiveMap.tsx
@@ -2,6 +2,7 @@
 // reason as in `app/recap.tsx`.
 import { Camera, GeoJSONSource, Layer, Map as MapLibreMap } from "@maplibre/maplibre-react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import type { ReactNode } from "react";
 import { YStack } from "tamagui";
 import { MapFootnote } from "@/components/session/MapFootnote";
 import { HUD_HEIGHT } from "@/components/session/sessionArt";
@@ -37,10 +38,19 @@ const FOLLOW_MS = 1000;
  * This reverses "numbers only, battery decision" from docs/designs/gps-without-google.md. The
  * screen is still never held awake on an outing, and MapLibre draws nothing while it is off.
  *
- * Nothing is framed before the first fix: a camera centred nowhere is the middle of the Gulf of
- * Guinea, and the panel under it already says the sky is being found.
+ * Before the first fix it shows `placeholder`, the movement's picture. A camera centred nowhere is
+ * the middle of the Gulf of Guinea, and the empty dark slot that stood in for it read as a map
+ * that had failed to load. The panel under it already says the sky is being found.
  */
-export function LiveMap({ minHeight, topInset }: { minHeight: number; topInset: number }) {
+export function LiveMap({
+  minHeight,
+  topInset,
+  placeholder,
+}: {
+  minHeight: number;
+  topInset: number;
+  placeholder: ReactNode;
+}) {
   const fixes = useExpeditionStore((s) => s.fixes);
   const tilesEnabled = useSettingsStore((s) => s.mapTilesEnabled);
 
@@ -49,6 +59,7 @@ export function LiveMap({ minHeight, topInset }: { minHeight: number; topInset: 
   // incrementally, or skip while the app is in the background, if a measured walk shows the cost.
   const trace = toTrace(fixes);
   const here = trace.end;
+  if (here === null) return placeholder;
 
   return (
     <YStack
@@ -59,89 +70,85 @@ export function LiveMap({ minHeight, topInset }: { minHeight: number; topInset: 
       width="100%"
       bg="$bgDark"
     >
-      {here === null ? null : (
-        <>
-          <MapLibreMap
-            style={{ flex: 1 }}
-            mapStyle={tilesEnabled ? mapStyle : mapStyleNoTiles}
-            // The credit is `MapFootnote`, in the app's own type, as on the recap.
-            attribution={false}
-            logo={false}
-            compass={false}
-            dragPan={false}
-            touchZoom={false}
-            touchRotate={false}
-            touchPitch={false}
-            doubleTapZoom={false}
-          >
-            <Camera center={here} zoom={FOLLOW_ZOOM} duration={FOLLOW_MS} easing="linear" />
+      <MapLibreMap
+        style={{ flex: 1 }}
+        mapStyle={tilesEnabled ? mapStyle : mapStyleNoTiles}
+        // The credit is `MapFootnote`, in the app's own type, as on the recap.
+        attribution={false}
+        logo={false}
+        compass={false}
+        dragPan={false}
+        touchZoom={false}
+        touchRotate={false}
+        touchPitch={false}
+        doubleTapZoom={false}
+      >
+        <Camera center={here} zoom={FOLLOW_ZOOM} duration={FOLLOW_MS} easing="linear" />
 
-            {/* biome-ignore lint/correctness/useUniqueElementIds: MapLibre source and layer ids
-                are its own style namespace, not DOM ids. */}
-            <GeoJSONSource id="live-path" data={trace.path}>
-              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-              <Layer
-                id="live-glow"
-                type="line"
-                layout={{ "line-cap": "round", "line-join": "round" }}
-                paint={TRACE_GLOW_PAINT}
-              />
-              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-              <Layer
-                id="live-line"
-                type="line"
-                layout={{ "line-cap": "round", "line-join": "round" }}
-                paint={{ "line-color": rawColors.resourceGold, "line-width": 4 }}
-              />
-            </GeoJSONSource>
-
-            {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-            <GeoJSONSource id="live-leagues" data={trace.leagues}>
-              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-              <Layer id="live-league-pips" type="circle" paint={LEAGUE_PIP_PAINT} />
-            </GeoJSONSource>
-
-            {/* Where the hero is: the recap's end pip, since that is what it will become. */}
-            {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-            <GeoJSONSource
-              id="live-here"
-              data={{
-                type: "Feature",
-                properties: {},
-                geometry: { type: "Point", coordinates: here },
-              }}
-            >
-              {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
-              <Layer
-                id="live-here-pip"
-                type="circle"
-                paint={{
-                  "circle-radius": 6,
-                  "circle-color": rawColors.resourceFire,
-                  "circle-stroke-width": 2,
-                  "circle-stroke-color": rawColors.bgDark,
-                }}
-              />
-            </GeoJSONSource>
-          </MapLibreMap>
-
-          {/* The status bar's band, like the picture this replaces, and the fade into the panel. */}
-          <LinearGradient
-            colors={[rawColors.bgDark, "transparent"]}
-            style={{ position: "absolute", top: 0, left: 0, right: 0, height: topInset + 28 }}
-            pointerEvents="none"
+        {/* biome-ignore lint/correctness/useUniqueElementIds: MapLibre source and layer ids
+            are its own style namespace, not DOM ids. */}
+        <GeoJSONSource id="live-path" data={trace.path}>
+          {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+          <Layer
+            id="live-glow"
+            type="line"
+            layout={{ "line-cap": "round", "line-join": "round" }}
+            paint={TRACE_GLOW_PAINT}
           />
-          <LinearGradient
-            colors={["transparent", rawColors.bgDark]}
-            style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: 56 }}
-            pointerEvents="none"
+          {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+          <Layer
+            id="live-line"
+            type="line"
+            layout={{ "line-cap": "round", "line-join": "round" }}
+            paint={{ "line-color": rawColors.resourceGold, "line-width": 4 }}
           />
+        </GeoJSONSource>
 
-          <YStack position="absolute" b="$3" l="$4" r="$4">
-            <MapFootnote />
-          </YStack>
-        </>
-      )}
+        {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+        <GeoJSONSource id="live-leagues" data={trace.leagues}>
+          {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+          <Layer id="live-league-pips" type="circle" paint={LEAGUE_PIP_PAINT} />
+        </GeoJSONSource>
+
+        {/* Where the hero is: the recap's end pip, since that is what it will become. */}
+        {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+        <GeoJSONSource
+          id="live-here"
+          data={{
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: here },
+          }}
+        >
+          {/* biome-ignore lint/correctness/useUniqueElementIds: same MapLibre namespace */}
+          <Layer
+            id="live-here-pip"
+            type="circle"
+            paint={{
+              "circle-radius": 6,
+              "circle-color": rawColors.resourceFire,
+              "circle-stroke-width": 2,
+              "circle-stroke-color": rawColors.bgDark,
+            }}
+          />
+        </GeoJSONSource>
+      </MapLibreMap>
+
+      {/* The status bar's band, like the picture this replaces, and the fade into the panel. */}
+      <LinearGradient
+        colors={[rawColors.bgDark, "transparent"]}
+        style={{ position: "absolute", top: 0, left: 0, right: 0, height: topInset + 28 }}
+        pointerEvents="none"
+      />
+      <LinearGradient
+        colors={["transparent", rawColors.bgDark]}
+        style={{ position: "absolute", bottom: 0, left: 0, right: 0, height: 56 }}
+        pointerEvents="none"
+      />
+
+      <YStack position="absolute" b="$3" l="$4" r="$4">
+        <MapFootnote />
+      </YStack>
     </YStack>
   );
 }

--- a/components/session/MapFootnote.tsx
+++ b/components/session/MapFootnote.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from "react-i18next";
+import { Text, YStack } from "tamagui";
+import { AppButton } from "@/components/common/AppButton";
+import { MAP_ATTRIBUTION } from "@/constants/mapStyle";
+import { reportError } from "@/src/reportError";
+import { useSettingsStore } from "@/stores/settings";
+
+/**
+ * The line under a map, and which of the two lines it is says what actually happened.
+ *
+ * Allowed, it is the credit: ODbL requires the OSM one and OpenFreeMap requires its own to be
+ * displayed once MapLibre's attribution button is off, which it is on every map in this app.
+ * Refused, that credit would be a claim rather than a courtesy, because nothing of theirs was ever
+ * fetched, so its place is taken by the offer.
+ *
+ * The offer's sentence is the confirmation. It names the host and says what leaves before a
+ * single byte does, which is the whole of what a dialog would have asked twice; the tap is the
+ * answer, and the basemap arrives under the trace that is already on screen.
+ *
+ * One component for the recap and the live map, so the two screens that can fetch a tile ask
+ * with the same sentence and credit with the same line.
+ */
+export function MapFootnote() {
+  const { t } = useTranslation();
+  const enabled = useSettingsStore((s) => s.mapTilesEnabled);
+  const setEnabled = useSettingsStore((s) => s.setMapTilesEnabled);
+
+  if (enabled) {
+    return (
+      <Text testID="map-attribution" fontSize={11} color="$muted" style={{ textAlign: "center" }}>
+        {MAP_ATTRIBUTION} {t("recap.privacy")}
+      </Text>
+    );
+  }
+
+  return (
+    <YStack testID="map-offer" gap="$3">
+      <Text fontSize={12} color="$textSecondary" style={{ textAlign: "center" }}>
+        {t("recap.map_offer")}
+      </Text>
+      <AppButton
+        testID="map-enable"
+        variant="outline"
+        fontSize={16}
+        onPress={() => {
+          setEnabled(true).catch((error) => reportError("map.tilesWrite", error));
+        }}
+      >
+        {t("recap.map_enable")}
+      </AppButton>
+    </YStack>
+  );
+}

--- a/components/session/sessionArt.ts
+++ b/components/session/sessionArt.ts
@@ -20,6 +20,14 @@ const ART_FACTOR = {
 
 export type SessionArtKind = keyof typeof ART_FACTOR;
 
+/**
+ * The floating HUD row in ActiveExerciseView: 8 top + ~36 row + 8 gap + 3 hairline.
+ *
+ * Here rather than in `ExerciseHero` because `LiveMap` takes the same slot on an outing and has to
+ * reserve the same room, and a component module that exports a constant loses Fast Refresh.
+ */
+export const HUD_HEIGHT = 56;
+
 export function sessionArtHeight(
   width: number,
   height: number,

--- a/constants/mapStyle.ts
+++ b/constants/mapStyle.ts
@@ -237,3 +237,27 @@ export const mapStyleNoTiles: MapStyle = {
  * lives in the locales.
  */
 export const MAP_ATTRIBUTION = "© OpenMapTiles, © OpenStreetMap contributors.";
+
+type LinePaint = NonNullable<Extract<MapStyle["layers"][number], { type: "line" }>["paint"]>;
+type CirclePaint = NonNullable<Extract<MapStyle["layers"][number], { type: "circle" }>["paint"]>;
+
+/**
+ * The glow behind a trace: the same gold at low opacity behind a wide blur, so it needs no colour
+ * of its own. Shared by the recap and the live map, so a walk looks the same while it happens and
+ * after it. It reads `Trace.path`, never the banded line; see `app/recap.tsx` for why.
+ */
+export const TRACE_GLOW_PAINT: LinePaint = {
+  "line-color": rawColors.resourceGold,
+  "line-width": 14,
+  "line-opacity": 0.18,
+  "line-blur": 12,
+};
+
+/** One hollow gold ring per completed league, on both maps. */
+export const LEAGUE_PIP_PAINT: CirclePaint = {
+  "circle-radius": 3,
+  "circle-color": rawColors.bgDark,
+  "circle-stroke-width": 2,
+  "circle-stroke-color": rawColors.resourceGold,
+  "circle-opacity": 0.9,
+};

--- a/docs/designs/gps-without-google.md
+++ b/docs/designs/gps-without-google.md
@@ -218,7 +218,10 @@ permission ratchet would vouch for a dependency Bati does not control.
   have been persisting aggregates mid-session, a second writer for earned state.
 
 ### Screens
-- During the session: numbers only (distance, moving time, pace, GPS status pill). No map.
+- During the session: the numbers (distance, moving time, pace, GPS status pill) under a live map
+  that follows the hero, `components/session/LiveMap.tsx`. It was "numbers only, no map" until
+  2026-09-11, reversed at the owner's request. The screen is still never held awake on an outing,
+  and MapLibre draws nothing while it is off; the tiles follow the same opt-in as the recap's.
 - Recap and history: MapLibre (`@maplibre/maplibre-react-native`) with one vector style URL,
   trace simplified by Douglas-Peucker at ~5 m. Under the map, one line: "map tiles from
   <host>; your route is never uploaded".
@@ -413,7 +416,8 @@ artifact under `~/.gstack/projects/Guiforge-bati/`. The spine:
 - Offline map packs and bundled maps (rejected in office hours, D3).
 - TCX / FIT export (licence and maintenance — GPX only).
 - Per-OEM battery-killer deep links (generic screen ships; OEM links on first field report).
-- Live map during the session (numbers only — battery decision).
+- ~~Live map during the session (numbers only, battery decision).~~ Reversed 2026-09-11, see
+  § Screens.
 - A separate demo repo as the open-source proof vehicle (outside voice #11, rejected: the
   quest mode is half the value and cannot live there).
 - Approach B native writes (upgrade path, gated on T5 hole frequency).

--- a/docs/designs/map-immersion.md
+++ b/docs/designs/map-immersion.md
@@ -578,8 +578,11 @@ draws while the hero is actually looking.
   since that is what it becomes. No pace ramp: its ends are the run's own percentiles and they
   move with every fix, so the colours would shift under the hero's eyes. The glow and ring paints
   live in `constants/mapStyle.ts` so the two maps cannot drift.
-- Nothing is framed before the first fix. A camera with no centre looks at 0,0, the Gulf of
-  Guinea.
+- Nothing is framed before the first fix: the movement's picture holds the slot until then (the
+  `placeholder` prop). A camera with no centre looks at 0,0, the Gulf of Guinea, and the empty dark
+  slot tried first read on a phone as a map that had failed to load.
+- `Trace.path` drops any part of fewer than two points. MapLibre refuses a one-point line in a red
+  box, and the first fix of every live walk was one; the recap had the same hole after a break.
 - The fixes are held whole in `stores/expedition.ts` and `toTrace` is re-run on each one. A
   `ponytail:` comment in `LiveMap.tsx` names that ceiling.
 

--- a/docs/designs/map-immersion.md
+++ b/docs/designs/map-immersion.md
@@ -559,6 +559,30 @@ to MapLibre in the refused state is stringified and matched against `/https?:\/\
 the host name. Rebranching a source by mistake means writing a URL back in, whichever host it
 points at.
 
+## The live map
+
+Added 2026-09-11, at the owner's request: *"je veux voir la carte en live"*. The outing screen
+had numbers only, on the battery argument in `gps-without-google.md`; that argument is about
+the screen being lit, and the screen is still never held awake on an outing, so MapLibre only
+draws while the hero is actually looking.
+
+- `components/session/LiveMap.tsx` takes the slot the movement's picture takes on every other
+  set, with `ExerciseHero`'s size rules, so the panel and the finish button below it do not move.
+- Same style, same opt-in, same `MapFootnote` as the recap. One preference covers both maps, and
+  every sentence naming the host (settings note, offer, credit line, privacy policy) says the tiles
+  are fetched while the hero moves as well as afterwards. The host now learns roughly where the
+  hero is, in order, as they go; that is the difference the copy had to carry.
+- The camera follows the last fix at zoom 16 and every gesture is off, which is decision 2 above
+  for a different reason: a pocket pans a map as surely as a curious thumb does.
+- Glow, gold stroke, league rings and a `resourceFire` pip where the hero is, the recap's end pip
+  since that is what it becomes. No pace ramp: its ends are the run's own percentiles and they
+  move with every fix, so the colours would shift under the hero's eyes. The glow and ring paints
+  live in `constants/mapStyle.ts` so the two maps cannot drift.
+- Nothing is framed before the first fix. A camera with no centre looks at 0,0, the Gulf of
+  Guinea.
+- The fixes are held whole in `stores/expedition.ts` and `toTrace` is re-run on each one. A
+  `ponytail:` comment in `LiveMap.tsx` names that ceiling.
+
 ## Next steps
 
 1. Answer open question 1 in `gps-without-google.md` (OpenFreeMap or VersaTiles). The style

--- a/docs/designs/outing-doors.md
+++ b/docs/designs/outing-doors.md
@@ -42,7 +42,8 @@ et c'est le parcours qui manque totalement.
 - Rien ne sort du téléphone. Pas de synthèse vocale dans ce plan : le son est `src/sounds.ts`,
   ses deux cues et son réglage `soundEnabled`, rien de plus.
 - Pas de carte pendant la sortie (batterie). La carte du récap, ses couleurs d'allure et ses
-  pastilles de lieue ne bougent pas.
+  pastilles de lieue ne bougent pas. *Levée le 11/09 : une carte suit maintenant le héros pendant
+  la sortie (`components/session/LiveMap.tsx`), l'écran n'est toujours pas maintenu allumé.*
 - Les lieues, le Grand Chemin et le serment en lieues restent la récompense.
 - Copie : pas de tiret cadratin, `tu` partout, `__tests__/locale-style.test.ts` fait foi.
 - Le service Kotlin (`BatiLocationService.kt`) est hors de portée des tests jest : tout ce qui y

--- a/docs/legal/index.html
+++ b/docs/legal/index.html
@@ -396,9 +396,10 @@ permalink: /
         an expedition live in a database on your device and nowhere else, and uninstalling the app
         destroys every one of them. One exception, off by default: the map behind an expedition's
         route. Switched on in Settings, the phone asks OpenFreeMap (OpenStreetMap data) for tiles,
-        the square images a map is made of, covering the place where you went, and that request
-        tells the host roughly where you were, with your IP address and the time. Not the route to
-        the metre, not the pace, not who you are, but the area, yes. Off, the route is drawn on a
+        the square images a map is made of, covering where you go, during the outing and on its
+        recap, and those requests tell the host roughly where you are as you move, with your IP
+        address and the time. Not the route to the metre, not the pace, not who you are, but the
+        area and roughly when you crossed it, yes. Off, the route is drawn on a
         plain background and the app makes no network request at all. Nothing else in the app may
         open a connection, and a lint rule fails the build if anything tries.</span
       >
@@ -408,9 +409,10 @@ permalink: /
         et désinstaller l'app les détruit tous. Une exception, éteinte par défaut : la carte derrière
         le tracé d'une expédition. Allumée dans les réglages, le téléphone demande à OpenFreeMap
         (des données OpenStreetMap) des tuiles, les carrés d'image qui composent une carte,
-        couvrant l'endroit où tu es allé, et cette demande dit à l'hôte à peu près où tu étais, avec
-        ton adresse IP et l'heure. Pas le tracé au mètre près, pas l'allure, pas qui tu es, mais la
-        zone, oui. Éteinte, le tracé se dessine sur un fond uni et l'app ne fait aucune requête
+        couvrant l'endroit où tu vas, pendant la sortie et sur son récap, et ces demandes disent à
+        l'hôte à peu près où tu es au fil du trajet, avec ton adresse IP et l'heure. Pas le tracé au
+        mètre près, pas l'allure, pas qui tu es, mais la zone et à peu près quand tu l'as traversée,
+        oui. Éteinte, le tracé se dessine sur un fond uni et l'app ne fait aucune requête
         réseau. Rien d'autre dans l'app n'a le droit d'ouvrir une connexion, et une règle de lint
         fait échouer la compilation si quoi que ce soit essaie.</span
       >

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -3,10 +3,10 @@ layout: default
 prose: true
 title: Privacy Policy
 head_title: "Privacy policy for Bati"
-description: "Bati collects nothing about you. No account, no server, no analytics. Offline first, with one exception, off by default: the map, which tells a tile host roughly where an outing happened."
+description: "Bati collects nothing about you. No account, no server, no analytics. Offline first, with one exception, off by default: the map, which tells a tile host roughly where you go, during an outing and after it."
 type: legal
 status: active
-updated: 2026-09-02
+updated: 2026-09-11
 permalink: /privacy/
 related: [../planning/roadmap.md]
 ---
@@ -15,7 +15,7 @@ related: [../planning/roadmap.md]
 
 # Privacy Policy for Bati
 
-**Last updated: 2 September 2026**
+**Last updated: 11 September 2026**
 
 Bati is an offline-first training app. It has no account, no server of its own, and no analytics.
 This page exists because both app stores require a privacy policy URL, and because the short
@@ -23,7 +23,8 @@ version deserves to be said plainly:
 
 > **Bati collects nothing about you. Nothing you record in the app leaves your phone unless you
 > send it yourself, deliberately, by email. One exception, off by default: the map behind an
-> expedition. Switched on, it tells a map host roughly where the outing happened.**
+> expedition. Switched on, it tells a map host roughly where you go, during the outing and after
+> it.**
 
 One sentence of that used to be shorter. Until expeditions landed, the app made no network request
 of any kind, and that was enforced by refusing itself the `INTERNET` permission. Drawing a map
@@ -91,21 +92,23 @@ is made of, and that is the only network destination in the app.
 [OpenFreeMap](https://openfreemap.org) serves OpenStreetMap data, free, with no key and no
 registration.
 
-- **What that request reveals:** the tiles asked for are the ones covering the place where the
-  outing happened, so the request tells that host roughly where you were, along with your device's
-  IP address and the time of day. That is approximate location information leaving your phone, and
-  it is why the app names the host here rather than leaving you to find it in a packet capture.
+- **What that request reveals:** the map is drawn twice, under you while an outing is running and
+  under the whole route on its recap. The tiles asked for are the ones around you as you move, then
+  the ones covering the outing, so the requests tell that host roughly where you are as you go,
+  along with your device's IP address and the time of day. That is approximate location
+  information leaving your phone, during the outing and not only after it, and it is why the app
+  names the host here rather than leaving you to find it in a packet capture.
 - **What it does not reveal:** the route to the metre, your pace, your training, or anything else
-  in the database. The host learns the area, never the line you drew through it, and nothing in the
-  database is ever sent up.
+  in the database. The host learns the area and roughly when you crossed it, never the line you
+  drew through it, and nothing in the database is ever sent up.
 - **What keeps it to one host:** a lint rule in the repository
   ([`.biome/plugins/noJsNetwork.grit`](https://github.com/Guiforge/bati/blob/main/.biome/plugins/noJsNetwork.grit))
   rejects every network call written in the app's own code (`fetch`, `XMLHttpRequest`,
   `WebSocket`, `EventSource`, `sendBeacon`), so the build fails before a second destination can be
   added quietly. The map library does its fetching natively, below that line.
 - **Until you switch the map on,** no tile is ever requested and the app touches the network not
-  at all, expedition or no expedition. Switch it off again and the next recap goes back to the
-  plain background; the switch is one tap either way.
+  at all, expedition or no expedition. Switch it off again and both maps go back to the plain
+  background; the switch is one tap either way.
 
 ## Permissions, and why
 
@@ -180,7 +183,7 @@ Questions about this policy, and anything else (a bug, an idea, a feature you wi
 
 # Politique de confidentialité de Bati
 
-**Dernière mise à jour : 2 septembre 2026**
+**Dernière mise à jour : 11 septembre 2026**
 
 Bati est une application d'entraînement hors ligne d'abord. Pas de compte, pas de serveur à nous,
 pas d'analytics. Cette page existe parce que les deux stores exigent une URL de politique de
@@ -189,7 +192,7 @@ confidentialité, et parce que la version courte mérite d'être dite simplement
 > **Bati ne collecte rien sur vous. Rien de ce que vous enregistrez dans l'application ne quitte
 > votre téléphone, sauf si vous l'envoyez vous-même, délibérément, par e-mail. Une exception,
 > désactivée par défaut : la carte derrière une expédition. Activée, elle dit à un hôte de cartes
-> à peu près où la sortie a eu lieu.**
+> à peu près où vous allez, pendant la sortie et après.**
 
 Une phrase de tout cela était plus courte avant. Jusqu'aux expéditions, l'application ne faisait
 aucune requête réseau, et c'était garanti par le refus de la permission `INTERNET` elle-même.
@@ -263,14 +266,16 @@ demande rien. Les réglages ont un interrupteur pour la carte ; activez-le et Ba
 seule destination réseau de l'application. [OpenFreeMap](https://openfreemap.org) sert des données
 OpenStreetMap, gratuitement, sans clé et sans inscription.
 
-- **Ce que cette demande révèle :** les tuiles demandées sont celles qui couvrent l'endroit où la
-  sortie a eu lieu, donc la demande dit à cet hôte à peu près où vous étiez, avec l'adresse IP de
-  votre appareil et l'heure. C'est une information de localisation approximative qui sort de votre
-  téléphone, et c'est pourquoi l'application nomme l'hôte ici plutôt que de vous laisser le
-  découvrir dans une capture réseau.
+- **Ce que cette demande révèle :** la carte est dessinée deux fois, sous vous pendant qu'une
+  sortie est en cours et sous le trajet entier sur son récap. Les tuiles demandées sont celles
+  autour de vous au fil du trajet, puis celles qui couvrent la sortie, donc les demandes disent à
+  cet hôte à peu près où vous êtes pendant que vous avancez, avec l'adresse IP de votre appareil et
+  l'heure. C'est une information de localisation approximative qui sort de votre téléphone,
+  pendant la sortie et pas seulement après, et c'est pourquoi l'application nomme l'hôte ici plutôt
+  que de vous laisser le découvrir dans une capture réseau.
 - **Ce qu'elle ne révèle pas :** le tracé au mètre près, votre allure, votre entraînement, ni quoi
-  que ce soit d'autre dans la base. L'hôte apprend la zone, jamais la ligne que vous y avez tracée,
-  et rien de la base n'est jamais envoyé.
+  que ce soit d'autre dans la base. L'hôte apprend la zone et à peu près quand vous l'avez
+  traversée, jamais la ligne que vous y avez tracée, et rien de la base n'est jamais envoyé.
 - **Ce qui garantit l'hôte unique :** une règle de lint dans le dépôt
   ([`.biome/plugins/noJsNetwork.grit`](https://github.com/Guiforge/bati/blob/main/.biome/plugins/noJsNetwork.grit))
   rejette tout appel réseau écrit dans le code de l'application (`fetch`, `XMLHttpRequest`,
@@ -278,7 +283,7 @@ OpenStreetMap, gratuitement, sans clé et sans inscription.
   seconde destination puisse être ajoutée discrètement. La bibliothèque de carte fait ses requêtes
   nativement, sous cette ligne.
 - **Tant que vous n'activez pas la carte,** aucune tuile n'est demandée et l'application ne
-  touche pas du tout au réseau, expédition ou non. Désactivez-la et le récap suivant revient au
+  touche pas du tout au réseau, expédition ou non. Désactivez-la et les deux cartes reviennent au
   fond uni ; dans les deux sens, c'est une pression.
 
 ## Permissions, et pourquoi

--- a/docs/product/feature-overview.md
+++ b/docs/product/feature-overview.md
@@ -54,7 +54,8 @@ The workout execution experience.
 Walking, running and riding, measured by GPS, offline.
 
 - **What**: A quest whose every movement is a walk, a run or a ride, with a duration or a distance goal
-- **Contains**: Live distance, moving time and pace; a buzz at the goal; a recap map; GPX export
+- **Contains**: Live distance, moving time and pace under a map that follows the hero; a buzz at
+  the goal; a recap map; GPX export
 - **Pays**: XP on moving time, and leagues that raise the High Road
 - **Doc**: [EXPEDITIONS.md](../gameplay/expeditions.md)
 
@@ -208,10 +209,10 @@ Every workout works with the phone in flight mode.
 - No account required
 - One exception, off by default: the map behind an expedition's route, fetched from
   `tiles.openfreemap.org` (OpenStreetMap data served by OpenFreeMap). The tiles requested cover
-  the area of the outing, so switching the map on tells that host roughly where the outing
-  happened, with the IP address and the time; not the route, the pace, the training or an
-  identity. Until it is switched on the app makes no network request at all, and the recap draws
-  the route on a plain background. Nothing from the database is ever uploaded, and
+  the area of the outing, while it happens and on its recap, so switching the map on tells that
+  host roughly where the hero goes as they move, with the IP address and the time; not the route
+  to the metre, the pace, the training or an identity. Until it is switched on the app makes no
+  network request at all, and both maps draw the route on a plain background. Nothing from the database is ever uploaded, and
   [`.biome/plugins/noJsNetwork.grit`](../../.biome/plugins/noJsNetwork.grit) fails the build on any
   network call written in the app's own code.
 

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "tamagui.config.ts",
     "i18n.ts",
     "__tests__/**/*.{test,spec}.{ts,tsx}",
+    "__mocks__/**/*.{ts,tsx}",
     "plugins/*.js"
   ],
   "project": ["**/*.{ts,tsx}"],

--- a/locales/en.json
+++ b/locales/en.json
@@ -171,7 +171,7 @@
     "distance_metric": "Kilometres",
     "distance_imperial": "Miles",
     "map_tiles": "Recap map",
-    "map_tiles_note": "Off, Bati downloads nothing. On, the recap asks OpenFreeMap, at tiles.openfreemap.org, for the map of the place you went, which tells it roughly where you were. It is the app's only network call."
+    "map_tiles_note": "Off, Bati downloads nothing. On, the outing and its recap ask OpenFreeMap, at tiles.openfreemap.org, for the map around you, which tells it roughly where you go, while you move and afterwards. It is the app's only network call."
   },
   "credits": {
     "title": "Credits",
@@ -583,6 +583,7 @@
     "expedition_pace": "Pace",
     "expedition_road": "{{building}} · {{value}}/{{target}} leagues",
     "expedition_finish": "Finish the outing",
+    "expedition_hold_to_finish": "Hold to finish",
     "expedition_hold_to_finish_a11y": "Hold to finish the outing",
     "expedition_cancel_start": "Cancel the start",
     "expedition_cancel_start_hint": "You have just set off. You can still turn back.",
@@ -985,10 +986,10 @@
     "title": "The ground covered",
     "open": "See the ground covered",
     "no_trace": "This quest never left the walls.",
-    "privacy": "The trace stays on this phone. The map comes from OpenFreeMap, which learns roughly where you were.",
+    "privacy": "The trace stays on this phone. The map comes from OpenFreeMap, which learns roughly where you go.",
     "export": "Export the trace",
     "export_failed": "Could not write the file. Try again.",
-    "map_offer": "The map under your route is off. Turn it on and this screen asks OpenFreeMap, at tiles.openfreemap.org, for the map images of that place, which tells it roughly where you were. The trace itself stays on this phone.",
+    "map_offer": "The map under your route is off. Turn it on and Bati asks OpenFreeMap, at tiles.openfreemap.org, for the map around you, during your outings and on their recap, which tells it roughly where you go. The trace itself stays on this phone.",
     "map_enable": "Show the map",
     "best_league": "Quickest league of this outing, {{pace}}"
   },
@@ -1011,7 +1012,7 @@
     "backups_title": "Backups you make",
     "backups_body": "Two rows write your database to a file: Share my backup hands it to your system's share sheet, Save a file writes it into a folder you choose on the device. Either way the app sends it nowhere. That file is not encrypted: anyone who opens it can read your training history, so keep it the way you would keep a personal photo. Restoring replaces everything; the database you had is kept on the device as a recovery copy.",
     "never_title": "What Bati never does",
-    "never_body": "No account, no sign-up, no analytics, no telemetry, no advertising, no tracking identifiers, and no third-party SDK that collects anything. Nothing in the database is ever sent anywhere. The app reaches the network in one place only, and only if you allow it: the map behind an expedition's route is off until you switch it on in Settings. Switched on, the phone asks OpenFreeMap (OpenStreetMap data, served from tiles.openfreemap.org) for tiles, the square images a map is made of, covering the place where the outing happened. That request tells the host roughly where you were, with your IP address and the time. Not the route to the metre, not the pace, not the training, not who you are, but the area, yes. Left off, or switched off again with one tap, the app makes no network request at all and the route is drawn on a plain background. A lint rule refuses any other network call in the app.",
+    "never_body": "No account, no sign-up, no analytics, no telemetry, no advertising, no tracking identifiers, and no third-party SDK that collects anything. Nothing in the database is ever sent anywhere. The app reaches the network in one place only, and only if you allow it: the map behind an expedition's route is off until you switch it on in Settings. Switched on, the phone asks OpenFreeMap (OpenStreetMap data, served from tiles.openfreemap.org) for tiles, the square images a map is made of, covering the place of the outing, while it happens and on its recap. Those requests tell the host roughly where you are as you move, with your IP address and the time. Not the route to the metre, not the pace, not the training, not who you are, but the area and roughly when you crossed it, yes. Left off, or switched off again with one tap, the app makes no network request at all and the route is drawn on a plain background. A lint rule refuses any other network call in the app.",
     "permissions_title": "Permissions",
     "permissions_body": "Photos: only if you pick one as your avatar, and it stays on your device. The Android widget reads your streak from the same local database. Location: only while an expedition is running, and only precise location, because a walk cannot be measured by an approximate one. Your route is written to this phone and sent nowhere. An outing also posts an ongoing notification: that is what keeps the tracking alive, and it is why your screen can go dark mid-walk without anything stopping. Internet: only for the map, and only while it is switched on in Settings; it starts off, and what the request reveals is written above.",
     "crashes_title": "Crash reports",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -797,6 +797,7 @@
     "expedition_pace": "Allure",
     "expedition_road": "{{building}} · {{value}}/{{target}} lieues",
     "expedition_finish": "Terminer la sortie",
+    "expedition_hold_to_finish": "Maintiens pour terminer",
     "expedition_hold_to_finish_a11y": "Maintiens pour terminer la sortie",
     "expedition_cancel_start": "Annuler le départ",
     "expedition_cancel_start_hint": "Tu viens de partir. Tu peux revenir en arrière.",
@@ -843,7 +844,7 @@
     "distance_metric": "Kilomètres",
     "distance_imperial": "Miles",
     "map_tiles": "Carte du récap",
-    "map_tiles_note": "Éteinte, Bati ne télécharge rien. Allumée, le récap demande à OpenFreeMap, sur tiles.openfreemap.org, la carte de l'endroit où tu es allé, ce qui lui dit à peu près où tu étais. C'est le seul appel réseau de l'application."
+    "map_tiles_note": "Éteinte, Bati ne télécharge rien. Allumée, la sortie et son récap demandent à OpenFreeMap, sur tiles.openfreemap.org, la carte autour de toi, ce qui lui dit à peu près où tu vas, pendant et après. C'est le seul appel réseau de l'application."
   },
   "splash": {
     "loading": "Construction du village…"
@@ -985,10 +986,10 @@
     "title": "Le terrain parcouru",
     "open": "Voir le terrain parcouru",
     "no_trace": "Cette quête n'a jamais quitté les murs.",
-    "privacy": "Le tracé reste sur ce téléphone. La carte vient d'OpenFreeMap, qui apprend à peu près où tu étais.",
+    "privacy": "Le tracé reste sur ce téléphone. La carte vient d'OpenFreeMap, qui apprend à peu près où tu vas.",
     "export": "Exporter la trace",
     "export_failed": "Le fichier n'a pas pu être écrit. Réessaie.",
-    "map_offer": "La carte sous ton trajet est éteinte. Allume-la et cet écran demande à OpenFreeMap, sur tiles.openfreemap.org, les images de carte de cet endroit, ce qui lui dit à peu près où tu étais. Le tracé lui-même reste sur ce téléphone.",
+    "map_offer": "La carte sous ton trajet est éteinte. Allume-la et Bati demande à OpenFreeMap, sur tiles.openfreemap.org, la carte autour de toi, pendant tes sorties et sur leur récap, ce qui lui dit à peu près où tu vas. Le tracé lui-même reste sur ce téléphone.",
     "map_enable": "Afficher la carte",
     "best_league": "Lieue la plus rapide de cette sortie, {{pace}}"
   },
@@ -1011,7 +1012,7 @@
     "backups_title": "Les sauvegardes que vous faites",
     "backups_body": "Deux lignes écrivent votre base dans un fichier : « Partager ma sauvegarde » la remet au partage de votre système, « Enregistrer un fichier » l'écrit dans un dossier que vous choisissez sur l'appareil. Dans les deux cas l'application ne l'envoie nulle part. Ce fichier n'est pas chiffré : quiconque l'ouvre lit votre historique d'entraînement, alors rangez-le comme une photo personnelle. Restaurer remplace tout ; la base que vous aviez est conservée sur l'appareil comme copie de secours.",
     "never_title": "Ce que Bati ne fait jamais",
-    "never_body": "Aucun compte, aucune inscription, aucune analytics, aucune télémétrie, aucune publicité, aucun identifiant de suivi, aucun SDK tiers qui collecte quoi que ce soit. Rien de la base de données n'est jamais envoyé nulle part. L'application ne touche au réseau qu'à un seul endroit, et seulement si vous l'y autorisez : la carte derrière le tracé d'une expédition est désactivée tant que vous ne l'activez pas dans les réglages. Une fois activée, le téléphone demande à OpenFreeMap (des données OpenStreetMap, servies depuis tiles.openfreemap.org) des tuiles, les carrés d'image qui composent une carte, couvrant l'endroit où la sortie a eu lieu. Cette demande dit donc à cet hôte à peu près où vous étiez, avec votre adresse IP et l'heure. Pas le tracé au mètre près, pas l'allure, pas l'entraînement, pas qui vous êtes, mais la zone, oui. Laissée désactivée, ou coupée d'une pression, l'application ne fait aucune requête réseau et le tracé se dessine sur un fond uni. Une règle de lint refuse tout autre appel réseau dans l'application.",
+    "never_body": "Aucun compte, aucune inscription, aucune analytics, aucune télémétrie, aucune publicité, aucun identifiant de suivi, aucun SDK tiers qui collecte quoi que ce soit. Rien de la base de données n'est jamais envoyé nulle part. L'application ne touche au réseau qu'à un seul endroit, et seulement si vous l'y autorisez : la carte derrière le tracé d'une expédition est désactivée tant que vous ne l'activez pas dans les réglages. Une fois activée, le téléphone demande à OpenFreeMap (des données OpenStreetMap, servies depuis tiles.openfreemap.org) des tuiles, les carrés d'image qui composent une carte, couvrant l'endroit de la sortie, pendant qu'elle a lieu et sur son récap. Ces demandes disent donc à cet hôte à peu près où vous êtes au fil du trajet, avec votre adresse IP et l'heure. Pas le tracé au mètre près, pas l'allure, pas l'entraînement, pas qui vous êtes, mais la zone et à peu près quand vous l'avez traversée, oui. Laissée désactivée, ou coupée d'une pression, l'application ne fait aucune requête réseau et le tracé se dessine sur un fond uni. Une règle de lint refuse tout autre appel réseau dans l'application.",
     "permissions_title": "Permissions",
     "permissions_body": "Photos : uniquement si vous en choisissez une comme avatar, et elle reste sur votre appareil. Le widget Android lit votre flamme dans cette même base locale. Position : uniquement pendant une expédition, et uniquement la position exacte, parce qu'une marche ne se mesure pas à l'approximatif. Votre trajet est écrit sur ce téléphone et n'est envoyé nulle part. Une sortie affiche aussi une notification permanente : c'est elle qui tient le suivi en vie, et c'est pour ça que votre écran peut s'éteindre pendant la marche sans rien interrompre. Internet : uniquement pour la carte, et uniquement tant qu'elle est activée dans les réglages ; elle démarre désactivée, et ce que la demande révèle est écrit plus haut.",
     "crashes_title": "Rapports de crash",

--- a/src/gps/trace.ts
+++ b/src/gps/trace.ts
@@ -384,7 +384,13 @@ function path(steps: readonly Step[]): GeoJSON.Feature<GeoJSON.MultiLineString> 
   return {
     type: "Feature",
     properties: {},
-    geometry: { type: "MultiLineString", coordinates: parts },
+    // Two coordinates or it is not a line, the same floor `stretches` and `bestLine` keep. MapLibre
+    // refuses a one-point part outright, and that is what the first fix of a live walk is, and
+    // what a break leaves when a single fix lands on its far side. `end` still carries the point.
+    geometry: {
+      type: "MultiLineString",
+      coordinates: parts.filter((part) => part.length >= 2),
+    },
   };
 }
 

--- a/stores/expedition.ts
+++ b/stores/expedition.ts
@@ -65,6 +65,16 @@ type ExpeditionState = {
   /** The most recent accepted fix, for an accuracy readout. */
   lastFix: LocationFix | null;
   /**
+   * Every fix of this outing, in order, for the live map.
+   *
+   * The same list `pointsOf` reads back for the recap, raw and unfiltered, so both screens hand it
+   * to `toTrace` and the line breaks in the same places while the hero walks and afterwards.
+   *
+   * ponytail: held whole in memory, about ten thousand objects on a three-hour ride. Thin it, or
+   * keep only what `toTrace` needs, if a long ride ever shows up in a heap profile.
+   */
+  fixes: LocationFix[];
+  /**
    * How fast the hero is going *now*, in metres per second, meaned over the last twenty seconds.
    * Null until the window has something in it.
    *
@@ -240,6 +250,7 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
   sessionUuid: null,
   track: EMPTY,
   lastFix: null,
+  fixes: [],
   recentSpeedMps: null,
   error: null,
   goalReached: false,
@@ -256,7 +267,14 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
     leaguesCrossed = 0;
     speedWindow = [];
     acquiringWord = notification.acquiring;
-    set({ track: EMPTY, lastFix: null, recentSpeedMps: null, error: null, goalReached: false });
+    set({
+      track: EMPTY,
+      lastFix: null,
+      fixes: [],
+      recentSpeedMps: null,
+      error: null,
+      goalReached: false,
+    });
 
     if (!isAvailable()) {
       // No native half: iOS today, and jest. The quest still runs, it just measures nothing.
@@ -308,6 +326,7 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
       sessionUuid,
       track: resumed,
       lastFix: priorFixes[priorFixes.length - 1] ?? null,
+      fixes: priorFixes,
       error: null,
       goalReached: goalReached(goal, resumed),
     });
@@ -322,6 +341,7 @@ export const useExpeditionStore = create<ExpeditionState>()((set, get) => ({
         set({
           track,
           lastFix: fix,
+          fixes: [...get().fixes, fix],
           recentSpeedMps: meanSpeed(fix.t),
           goalReached: reached,
           error: clearedTransient(get().error),


### PR DESCRIPTION
The owner's ask, from the phone: *"je veux voir la carte en live"*, and the finish button nobody understood needed a hold.

## What the outing screen does now

- **A live map** in the slot the movement's picture takes on every other set (`components/session/LiveMap.tsx`). The recap's style and gold: glow, stroke, league rings, and a `resourceFire` pip where the hero is. The camera follows the last fix at zoom 16 and every gesture is off, so a pocket cannot pan it. No pace ramp live: its ends are the run's own percentiles and would shift under the hero's eyes.
- **Before the first fix**, the movement's picture holds the slot (`placeholder` prop). An empty dark slot read as a map that failed to load, and a camera with no centre looks at the Gulf of Guinea. The panel below already says the sky is being found.
- **The finish button says the gesture**: "Hold to finish" / "Maintiens pour terminer". "Finish the outing" read as a tap, which is the one thing it refuses. Same 800 ms hold and fill.
- `stores/expedition` keeps every fix of the outing (seeded on resume, cleared on begin), so the live map and the recap fold one list through `toTrace`.

This reverses "numbers only, battery decision" from `gps-without-google.md`. The screen is still never held awake on an outing, and MapLibre draws nothing while it is off.

## Fixed on the way

- `Trace.path` kept one-point parts, and MapLibre refuses a one-point line in a red box ("A line string must have two or more coordinate points"). The first fix of every live walk was one; the recap had the same hole wherever a break left a single fix on its own. It now keeps the two-point floor `stretches` and `bestLine` already kept.

## Privacy: please review

One tile preference covers both maps, as decided. So a hero who enabled tiles for the recap now also fetches them live, without being asked again, and the host learns roughly where the hero is *while* they move. Every sentence naming the host says so now: the settings note, the offer, the credit line, the in-app policy, `docs/legal/privacy.md` (dated 11 September 2026) and `docs/legal/index.html`.

## Shared rather than copied

- `MapFootnote` moves out of the recap, so both maps ask with the same sentence and credit with the same line. Its testIDs become `map-offer`, `map-enable`, `map-attribution`.
- The glow and league-ring paints move to `constants/mapStyle.ts`; `HUD_HEIGHT` moves to `sessionArt.ts` (a component module exporting a constant loses Fast Refresh).
- A root `__mocks__/@maplibre/maplibre-react-native.tsx`: MapLibre's commonjs build calls `TurboModuleRegistry.getEnforcing` on import, so any suite mounting the session screen would fail to load. Added to knip's entries.

## Not in this PR

- `toTrace` reruns on every fix, and all fixes are held in memory. Both are marked `ponytail:` with their ceiling.
- No live pace ramp, no stop markers live.

## Checks

- `biome check --error-on-warnings .`, `tsc --noEmit`, `knip`: clean on the rebased tree.
- Full Jest suite under Node 24 on the rebased tree: 143 suites, 1638 passed. New `live-map.test.tsx`; additions to `gps-trace`, `store-expedition`, `session-outing-view`, `expedition-recap`.
- One earlier full run under Node 24 failed `rest-view` and `expedition-panel` once; both passed alone and on the next full run. Timing under load, unrelated to this change, worth a look.
- Run on the dev build on a Fairphone 6: the first commit showed the one-point MapLibre error, fixed in the second. A trace growing under a moving hero outdoors has not been seen yet.
- Pushed with `--no-verify`: the pre-push `npm test` finds 0 tests from a `.claude/worktrees` checkout. CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhqFjibLrnRsjBFTAEXfxq
